### PR TITLE
conformance(report): a skip is never a pass — in the JSON verdict too, and the report dates itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 protocol/site/dist/
 
 protocol/site/dist/
+*.egg-info/

--- a/protocol/conformance/README.md
+++ b/protocol/conformance/README.md
@@ -81,6 +81,18 @@ A few of them are worth calling out, because they catch things a schema check ne
 verified, because a suite that hides unrun checks behind a green summary is how a suite starts
 lying about the thing it exists to establish.
 
+The JSON report holds itself to the same rule, because it is the artifact published as evidence
+for a conformance claim and its reader is frequently not the person who ran it:
+
+- `conformant` is `true` only when every check ran and none failed or errored. A single skip
+  makes it `false`.
+- `conformant_with_skips` is `true` when nothing failed or errored — the checks that ran are
+  clean, and the ones that didn't are enumerated in `skipped_not_verified` by id, so the report
+  says exactly what it did not establish.
+- `suite_version` and `generated_at` (UTC) tie the report to the suite revision and the moment
+  that produced it. A report without these fields predates suite `2026.8.11.post1`; the
+  checked-in reports from earlier runs are of that older shape.
+
 ## Reference implementation results
 
 HarnessRouter Community Edition 0.3.0, the reference implementation in this repository, run against

--- a/protocol/conformance/pyproject.toml
+++ b/protocol/conformance/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uhp-conformance"
-version = "2026.8.11"
+version = "2026.8.11.post1"
 description = "Conformance suite for the Unified Harness Protocol (UHP)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/protocol/conformance/tests/test_report.py
+++ b/protocol/conformance/tests/test_report.py
@@ -1,0 +1,67 @@
+"""The report is the published evidence for a conformance claim, so its verdict fields are the
+contract under test here: a skip must never disappear into a green `conformant`, and the file
+must date itself and name the suite revision that produced it (issue #7)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from uhp_conformance import __version__
+from uhp_conformance.registry import CheckResult, Outcome
+from uhp_conformance.report import highest_class, render, to_json
+
+
+def _r(id, outcome, cls="core", detail=""):
+    return CheckResult(id, f"title {id}", cls, "spec §x", outcome, detail)
+
+
+CLEAN = [_r("B-01", Outcome.PASS), _r("B-02", Outcome.PASS)]
+SKIPPY = [_r("B-01", Outcome.PASS), _r("B-02", Outcome.SKIP, detail="no session api"),
+          _r("B-03", Outcome.SKIP, detail="no files api")]
+FAILING = [_r("B-01", Outcome.PASS), _r("B-02", Outcome.FAIL, detail="wrong status")]
+
+
+def test_clean_run_is_conformant():
+    d = json.loads(to_json(CLEAN, "http://t", "core"))
+    assert d["conformant"] is True
+    assert d["conformant_with_skips"] is True
+    assert d["skipped_not_verified"] == []
+
+
+def test_a_skip_is_never_a_pass_in_the_json_verdict():
+    d = json.loads(to_json(SKIPPY, "http://t", "core"))
+    assert d["conformant"] is False
+    assert d["conformant_with_skips"] is True
+    assert d["skipped_not_verified"] == ["B-02", "B-03"]
+
+
+def test_failures_fail_both_verdicts():
+    d = json.loads(to_json(FAILING, "http://t", "core"))
+    assert d["conformant"] is False
+    assert d["conformant_with_skips"] is False
+
+
+def test_report_dates_itself_and_names_the_suite():
+    d = json.loads(to_json(CLEAN, "http://t", "core"))
+    assert d["suite_version"] == __version__
+    stamped = datetime.strptime(d["generated_at"], "%Y-%m-%dT%H:%M:%SZ")
+    assert abs((datetime.now(timezone.utc).replace(tzinfo=None) - stamped).total_seconds()) < 60
+
+
+def test_human_summary_speaks_the_same_vocabulary():
+    out = render(SKIPPY, "http://t", "core", plain=True)
+    assert "CONFORMANT WITH SKIPS" in out
+    assert "A skip is not a pass." in out
+    clean = render(CLEAN, "http://t", "core", plain=True)
+    assert "CONFORMANT WITH SKIPS" not in clean
+    assert "CONFORMANT" in clean
+
+
+def test_highest_class_is_strict():
+    # "Fully passed" means every check at and below the class ran and passed: fails, errors,
+    # skips, and classes with no results at all each break the ladder.
+    assert highest_class(CLEAN) == "core"          # only core ran — full is not creditable
+    assert highest_class(SKIPPY) == ""             # a skipped check was not verified
+    assert highest_class(FAILING) == ""
+    full = [_r(f"{c}-01", Outcome.PASS, cls=c) for c in ("core", "extended", "full")]
+    assert highest_class(full) == "full"

--- a/protocol/conformance/uhp_conformance/__init__.py
+++ b/protocol/conformance/uhp_conformance/__init__.py
@@ -1,3 +1,3 @@
 """UHP conformance suite — the definition of "conformant" for the Unified Harness Protocol."""
-__version__ = "2026.8.11"
+__version__ = "2026.8.11.post1"
 UHP_VERSION = "2026-08-11"

--- a/protocol/conformance/uhp_conformance/report.py
+++ b/protocol/conformance/uhp_conformance/report.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
+
+from . import __version__
 from .registry import CLASSES, Outcome
 
 GREEN, RED, YELLOW, GREY, BOLD, RESET = (
@@ -51,23 +54,31 @@ def render(results, target: str, cls: str, plain: bool = False) -> str:
         lines.append(c(f"    NOT CONFORMANT at class '{cls}'", RED))
         if achieved:
             lines.append(f"    Highest class fully passed: {achieved}")
+    elif n[Outcome.SKIP]:
+        # Same vocabulary as the JSON report: skips demote the verdict, they never vanish into it.
+        lines.append(c(f"    CONFORMANT WITH SKIPS — UHP 2026-08-11 ({cls})", YELLOW))
+        lines.append(c("    Note: skipped checks were not verified. A skip is not a pass.", YELLOW))
     else:
         lines.append(c(f"    CONFORMANT — UHP 2026-08-11 ({cls})", GREEN))
-        if n[Outcome.SKIP]:
-            lines.append(c("    Note: skipped checks were not verified. A skip is not a pass.", YELLOW))
     lines.append("")
     return "\n".join(lines)
 
 
 def highest_class(results) -> str:
-    """The highest class with no failures or errors, counting the classes below it too."""
+    """The highest class every check of which — and of the classes below it — ran and passed.
+
+    "Fully passed" means exactly that: a fail or error anywhere at or below the class breaks
+    the ladder, and so does a skip, because a skipped check was not verified. A class with no
+    results at all breaks it too — before this rule, a run that only exercised `core` reported
+    `highest_class_passed: "full"`, crediting classes that never ran (issue #7's green-summary
+    shape, in class form)."""
     best = ""
     for k in CLASSES:
         upto = CLASSES[: CLASSES.index(k) + 1]
         group = [r for r in results if r.cls in upto]
-        if not group:
-            continue
-        if any(r.outcome in (Outcome.FAIL, Outcome.ERROR) for r in group):
+        if any(r.outcome is not Outcome.PASS for r in group):
+            break
+        if not any(r.cls == k for r in results):
             break
         best = k
     return best
@@ -92,9 +103,23 @@ def to_json(results, target: str, cls: str) -> str:
     return json.dumps({
         "protocol": "uhp",
         "protocol_version": "2026-08-11",
+        # The suite revision and the moment of the run, because this file is published as
+        # EVIDENCE (GOVERNANCE.md § Conformance claims) and evidence that cannot be dated or
+        # tied to the suite that produced it has to be dated in prose somewhere else — which is
+        # exactly what happened to the 0.3.0 report. A report without these fields predates
+        # suite 2026.8.11.post1.
+        "suite_version": __version__,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "target": target,
         "requested_class": cls,
-        "conformant": n["fail"] == 0 and n["error"] == 0,
+        # A skip is never a pass (README), and the consumer of this file is frequently not the
+        # person who ran the suite — so the verdict field itself goes strict: a run in which
+        # checks never executed is not "conformant", however green the rest of it is.
+        # `conformant_with_skips` keeps the old meaning under an honest name, and
+        # `skipped_not_verified` names the checks a reader must not assume anything about.
+        "conformant": n["fail"] == 0 and n["error"] == 0 and n["skip"] == 0,
+        "conformant_with_skips": n["fail"] == 0 and n["error"] == 0,
+        "skipped_not_verified": [r.id for r in results if r.outcome is Outcome.SKIP],
         "highest_class_passed": highest_class(results),
         "summary": {**n, "total": len(results)},
         "checks": [{"id": r.id, "title": r.title, "class": r.cls, "spec": r.spec,


### PR DESCRIPTION
Closes #7. Reported by @asj305 — the fix takes the strict shape proposed there.

## The defect

The suite README states **"a skip is never a pass"**, and the human renderer honours it — but `to_json()` set `conformant: true` whenever nothing failed or errored, so a run in which most checks never executed serialised as `"conformant": true, "highest_class_passed": "full"`. The JSON is the artifact `GOVERNANCE.md` § Conformance claims expects to be published as evidence, and its reader is frequently not the person who ran it. The human path was guarded; the machine path lied.

## What this changes

- **`conformant` is strict**: every check ran and none failed or errored. A single skip makes it `false`.
- **`conformant_with_skips`** keeps the old meaning under an honest name, and **`skipped_not_verified`** enumerates the check ids the report establishes nothing about — the part that makes a published report self-describing.
- **`suite_version` and `generated_at` (UTC)** tie the report to the suite revision and the moment that produced it. The 0.3.0 report had to be dated in prose because the file could not date itself. Suite version bumps to `2026.8.11.post1`; a report without these fields predates it.
- **`highest_class()` goes strict the same way**: fails, errors, skips, and classes with no results at all now break the ladder. The last one is an adjacent bug this exposed — a run that only exercised `core` reported `highest_class_passed: "full"`, crediting classes that never ran.
- **The human summary speaks the same vocabulary**: a clean run with skips prints `CONFORMANT WITH SKIPS` in yellow (plus the existing note), instead of a green `CONFORMANT` with a footnote — so the two paths can't diverge again.

The checked-in reports under `reports/` are artifacts of the older suite and are left as they are; the README now says how to read their shape (no `generated_at` ⇒ pre-`2026.8.11.post1`).

## Verification

`protocol/conformance/tests/test_report.py` (new): strict verdict on skips, both verdicts on failures, skip-id enumeration, self-dating within the run, human/JSON vocabulary agreement, and the strict ladder — 6/6 passing. A clean 52/52 full-class run (the checked-in 0.8.0 shape) is unaffected: `conformant: true`, ladder `full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)