### PR TITLE
fix(dsh): survive providers that reject reasoning_effort

### DIFF
--- a/runner/dsh_driver.py
+++ b/runner/dsh_driver.py
@@ -49,10 +49,31 @@ def _rewrite_sse_line(line: bytes) -> bytes:
         return line
 
 
+# The deepseek-official adapter sends `reasoning_effort` on every request — DeepSeek's own API
+# takes it, but aggregators serving deepseek/* over the OpenAI shape refuse the whole request
+# (LLMTR: 'The "reasoning_effort" parameter is not supported by "deepseek/deepseek-v4-pro"',
+# captured 2026-08-20 by conformance T-01). The relay retries such a rejection ONCE without the
+# parameter and then strips it for the rest of the turn, so a provider that accepts it keeps it
+# and one that refuses it costs one extra round trip, once. Flipped by _Relay, read per request.
+_strip_reasoning_effort = False
+
+
+def _drop_reasoning_effort(body: bytes) -> bytes:
+    try:
+        obj = json.loads(body)
+        if isinstance(obj, dict) and "reasoning_effort" in obj:
+            del obj["reasoning_effort"]
+            return json.dumps(obj, separators=(",", ":")).encode()
+    except Exception:  # noqa: BLE001 — a body we cannot parse is a body we must not alter
+        pass
+    return body
+
+
 class _Relay(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def do_POST(self):  # noqa: N802
+        global _strip_reasoning_effort
         body = self.rfile.read(int(self.headers.get("content-length") or 0))
         # The adapters' base URLs point at this relay and they append their own API paths
         # (/v1/chat/completions, /v1/responses, /v1/messages); the upstream base ends in /v1 —
@@ -65,18 +86,29 @@ class _Relay(http.server.BaseHTTPRequestHandler):
         headers["authorization"] = f"Bearer {UPSTREAM_KEY}"
         headers["x-api-key"] = UPSTREAM_KEY   # the anthropic-messages spelling; harmless elsewhere
         headers.setdefault("accept", "*/*")
-        req = urllib.request.Request(UPSTREAM_BASE.rstrip("/") + tail,
-                                     data=body, method="POST", headers=headers)
-        try:
-            resp = urllib.request.urlopen(req, timeout=600)
-        except urllib.error.HTTPError as e:  # pass provider errors through verbatim
-            data = e.read()
-            self.send_response(e.code)
-            self.send_header("content-type", e.headers.get("content-type") or "application/json")
-            self.send_header("content-length", str(len(data)))
-            self.end_headers()
-            self.wfile.write(data)
-            return
+        if _strip_reasoning_effort:
+            body = _drop_reasoning_effort(body)
+        resp = None
+        for attempt in (0, 1):
+            req = urllib.request.Request(UPSTREAM_BASE.rstrip("/") + tail,
+                                         data=body, method="POST", headers=headers)
+            try:
+                resp = urllib.request.urlopen(req, timeout=600)
+                break
+            except urllib.error.HTTPError as e:
+                data = e.read()
+                stripped = _drop_reasoning_effort(body)
+                if attempt == 0 and b"reasoning_effort" in data and stripped != body:
+                    _strip_reasoning_effort = True
+                    body = stripped
+                    continue
+                # pass provider errors through verbatim
+                self.send_response(e.code)
+                self.send_header("content-type", e.headers.get("content-type") or "application/json")
+                self.send_header("content-length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
         ctype = resp.headers.get("content-type") or ""
         # The empty-string id/name quirk is a chat-completions stream shape; other protocols
         # (anthropic-messages, openai-responses) pass through byte-faithful.

--- a/runner/tests/test_dsh_normalize.py
+++ b/runner/tests/test_dsh_normalize.py
@@ -202,3 +202,22 @@ def test_compose_cordis_v1_normalization_per_api(tmp_path, monkeypatch):
     out_o = pathlib.Path(dsh_driver._compose_cordis(home, [], llm={"api": "openai-responses"},
                                                     relay_port=9999, model="gpt-5.4-mini")).read_text()
     assert "baseURL: http://127.0.0.1:9999/v1" in out_o
+
+
+# ── reasoning_effort strip-and-retry (conformance T-01 against LLMTR, 2026-08-20) ──────────────
+# The deepseek-official adapter sends reasoning_effort unconditionally; aggregators serving
+# deepseek/* over the OpenAI shape refuse the whole request. The relay retries once without the
+# parameter and then strips it for the rest of the turn.
+
+def test_drop_reasoning_effort_removes_only_that_key():
+    body = json.dumps({"model": "deepseek-v4-pro", "reasoning_effort": "high",
+                       "messages": [{"role": "user", "content": "hi"}]}).encode()
+    out = json.loads(dsh_driver._drop_reasoning_effort(body))
+    assert "reasoning_effort" not in out
+    assert out["model"] == "deepseek-v4-pro" and out["messages"][0]["content"] == "hi"
+
+
+def test_drop_reasoning_effort_leaves_other_bodies_alone():
+    for body in (b"not json at all", b"[1,2,3]",
+                 json.dumps({"model": "m", "messages": []}).encode()):
+        assert dsh_driver._drop_reasoning_effort(body) == body


### PR DESCRIPTION
The deepseek-official adapter sends `reasoning_effort` on every request. DeepSeek's own API takes it; aggregators serving `deepseek/*` over the OpenAI shape refuse the whole request — LLMTR answers *'The "reasoning_effort" parameter is not supported by "deepseek/deepseek-v4-pro"'*, and that single rejection failed four full-class conformance checks (T-01, S-03, S-07, X-05) and starved X-07 of its artifact.

The loopback relay (which exists for exactly this class of aggregator-shape repair) now retries such a rejection once without the parameter, then strips it for the rest of the turn: a provider that accepts `reasoning_effort` keeps it, one that refuses it costs one extra round trip, once.

## Verification

- Unit: `runner/tests/test_dsh_normalize.py` gains strip-only-that-key / leave-other-bodies-alone tests — 56/56 passing.
- Live: full conformance class against the dsh harness on `deepseek-v4-pro` through an LLMTR-only instance went **47/52 (4 failed, 1 skipped) → 52/52 CONFORMANT (full)**, run with the #8 suite. With this fix all five built-in harnesses (claude, codex, hermes, pi, dsh) are 52/52 full-class conformant on that instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)