### PR TITLE
fix(gateway): failed Responses now carry a spec-valid Error object

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -3978,9 +3978,14 @@ class _RespTranslator:
         return evs
 
     def fail(self, message: str) -> list[dict]:
-        self.error = {"code": "harness_error", "message": message}
+        # The spec's Error object (schema.json §Error) requires `type` from the closed enum,
+        # with `code` left for the SPECIFIC condition — emitting the type in `code` and no
+        # `type` at all made every failed Response fail schema validation, which conformance
+        # T-01/S-03/S-07 caught the first time a run actually failed (issue #7's suite, run
+        # 2026-08-20). The error EVENT mirrors error.code, so the two never disagree.
+        self.error = {"type": "harness_error", "code": "turn_failed", "message": message}
         evs = self._close_cur()
-        evs.append(self._ev("error", code="harness_error", message=message, param=None))
+        evs.append(self._ev("error", code="turn_failed", message=message, param=None))
         evs.append(self._ev("response.failed", response=self._response_obj("failed")))
         return evs
 
@@ -5608,7 +5613,7 @@ async def create_response(body: CreateResponseBody, request: Request):
                         max_step=max_step, timeout_s=timeout_s, hdr_vals=hdr_vals,
                         partial_messages=want_partial, codex_appserver=want_appserver, hv=hv)
                     if status == "failed":
-                        tr.error = {"code": "harness_error",
+                        tr.error = {"type": "harness_error", "code": "connections_exhausted",
                                     "message": (json.dumps(rec.get("tried") or [])[:400]) or "turn failed"}
                     for ev in tr.complete(status, produced):
                         await bus_emit_bg(ev)
@@ -5658,7 +5663,7 @@ async def create_response(body: CreateResponseBody, request: Request):
                             user_text=user_text, harness_id=harness_id, max_step=max_step,
                             timeout_s=timeout_s, hdr_vals=hdr_vals, partial_messages=want_partial, codex_appserver=want_appserver, hv=hv)
                         if status == "failed":
-                            tr.error = {"code": "harness_error",
+                            tr.error = {"type": "harness_error", "code": "connections_exhausted",
                                         "message": (json.dumps(rec.get("tried") or [])[:400]) or "turn failed"}
                         for ev in tr.complete(status, produced):
                             await emit(ev)
@@ -5717,13 +5722,13 @@ async def create_response(body: CreateResponseBody, request: Request):
                 user_text=user_text, harness_id=harness_id, max_step=max_step,
                 timeout_s=timeout_s, hdr_vals=hdr_vals, partial_messages=want_partial, codex_appserver=want_appserver, hv=hv)
             if status == "failed":
-                tr.error = {"code": "harness_error",
+                tr.error = {"type": "harness_error", "code": "connections_exhausted",
                             "message": (json.dumps(rec.get("tried") or [])[:400]) or "turn failed"}
             for ev in tr.complete(status, produced):
                 await bus_emit(ev)
             obj = tr._response_obj(status)
     except Exception as e:  # noqa: BLE001
-        tr.error = {"code": "harness_error", "message": str(e)[:300]}
+        tr.error = {"type": "server_error", "code": "unhandled_exception", "message": str(e)[:300]}
         obj = tr._response_obj("failed")
         status = "failed"
     await persist(status)

--- a/gateway/tests/test_response_error_envelope.py
+++ b/gateway/tests/test_response_error_envelope.py
@@ -1,0 +1,67 @@
+"""A failed Response must validate against the spec's Error object.
+
+The schema (protocol/schema/uhp-2026-08-11.schema.json, $defs.Error) requires `type` from a
+closed enum plus `code` and `message`. The gateway used to emit {"code": "harness_error",
+"message": ...} — the type in the code slot and no type at all — so EVERY failed turn produced
+a spec-invalid Response. Nothing noticed until a conformance run actually failed a turn
+(TokenRouter rejecting hermes's empty text block, LLMTR rejecting dsh's reasoning_effort,
+both 2026-08-20): T-01/S-03/S-07 then flagged the envelope rather than just the failure.
+
+This validates the envelope at the source, so the invariant holds without a live failing turn.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+import jsonschema
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_SCHEMA = os.path.join(_ROOT, "protocol", "schema", "uhp-2026-08-11.schema.json")
+_APP = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "app.py")
+
+
+def _error_schema() -> dict:
+    s = json.load(open(_SCHEMA))
+    return {"$defs": s["$defs"], **s["$defs"]["Error"]}
+
+
+def _resp_translator():
+    """Import lazily: app.py wants env + network at import time in some configurations."""
+    from app import _RespTranslator
+    return _RespTranslator
+
+
+def test_failed_turn_error_validates_against_the_spec():
+    tr = _resp_translator()("resp_test", "some-model", None, False, 0.0)
+    tr.fail("provider said no")
+    jsonschema.validate(tr.error, _error_schema())
+    assert tr.error["type"] == "harness_error"
+    assert tr.error["code"] == "turn_failed"
+
+
+def test_failed_response_object_validates_end_to_end():
+    s = json.load(open(_SCHEMA))
+    tr = _resp_translator()("resp_test", "some-model", None, False, 0.0)
+    tr.fail("provider said no")
+    obj = tr._response_obj("failed")
+    jsonschema.validate(obj, {"$defs": s["$defs"], **s["$defs"]["Response"]})
+
+
+def test_every_error_assignment_in_source_carries_a_spec_type():
+    """The other emission sites build their dicts inline with runtime values, so they are
+    checked at the source: every `.error = {...}` literal must lead with a `type` from the
+    spec's enum — the shape that was missing everywhere before this test existed."""
+    src = open(_APP).read()
+    enum = {"invalid_request_error", "authentication_error", "permission_error",
+            "rate_limit_error", "harness_error", "server_error"}
+    sites = re.findall(r'\.error = \{("(?:type|code)": "[a-z_]+")', src)
+    assert sites, "no error assignments found — the pattern moved, update this test"
+    for lead in sites:
+        key, val = re.match(r'"(\w+)": "([a-z_]+)"', lead).groups()
+        assert key == "type" and val in enum, f".error literal leads with {lead}, not a spec type"


### PR DESCRIPTION
The spec's Error object (`schema.json` §Error) requires `type` from the closed enum plus `code` and `message`. The gateway emitted `{"code": "harness_error", "message": …}` — the type in the code slot, no `type` at all — so **every failed turn produced a spec-invalid Response**, on every harness. Nothing noticed until a conformance run actually failed a turn: running the #8 suite against a TokenRouter-only instance, T-01/S-03/S-07/X-05 flagged the envelope on top of the underlying provider failures.

Shape now:
- harness-reported failure → `type: harness_error, code: turn_failed`
- connection ladder exhausted → `type: harness_error, code: connections_exhausted` (tried-ledger in `message`, as before)
- unhandled exception → `type: server_error, code: unhandled_exception`
- the SSE `error` event mirrors `error.code`, so event and response never disagree.

## Verification

- `gateway/tests/test_response_error_envelope.py` (new): validates `fail()`'s envelope and a full failed Response against the schema, plus a source-level check that every `.error` literal leads with a spec `type` — 3/3 passing.
- Live: rerunning the failing hermes leg through TokenRouter on a patched instance (result in the PR thread when complete).

Found while running the conformance matrix across all five harnesses × {LLMTR, TokenRouter}; siblings: #8 (report honesty), #10 (dsh reasoning_effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)