### PR TITLE
test(media): scope the no-poll assertions to the job under test

### DIFF
--- a/gateway/tests/test_media_mcp.py
+++ b/gateway/tests/test_media_mcp.py
@@ -2840,12 +2840,15 @@ def test_deleting_the_agent_stops_and_buries_its_jobs(api, client, kit, provider
     provider.video_bytes = _mp4(1.0)
     jid = _ok(_call(client, _cred(hid, sid), "generate_video",
                     {"prompt": "a", "seconds": 6}))["job_id"]
+    task = asyncio.run(app._media_job_get(jid))["provider_task_id"]
     assert api.delete(f"/v1/harnesses/{hid}").status_code == 200
 
     _due(jid)
     _calls.clear()
     asyncio.run(app._media_sweep())
-    assert [c["url"] for c in _calls if "/video/generations/" in c["url"]] == []
+    # Scoped to THIS job's task: on a slow runner an earlier test's still-live job can come due
+    # mid-sweep, and its poll is correct behaviour, not the regression this test guards.
+    assert [c["url"] for c in _calls if f"/video/generations/{task}" in c["url"]] == []
     job = asyncio.run(app._media_job_get(jid))
     assert job["status"] != "succeeded" and not job.get("media_id")
     assert asyncio.run(app._blob_list_all(f"media/{sid}/", kb=app.BLOB_KB)) == []
@@ -2866,11 +2869,12 @@ def test_switching_the_media_server_off_stops_its_jobs_and_switching_it_on_resum
     jid = _ok(_call(client, _cred(hid, sid), "generate_video",
                     {"prompt": "a", "seconds": 6}))["job_id"]
 
+    task = asyncio.run(app._media_job_get(jid))["provider_task_id"]
     assert _save_config(api, hid, [{**_entry_of(hid), "enabled": False}]).status_code == 200
     _due(jid)
     _calls.clear()
     asyncio.run(app._media_sweep())
-    assert [c["url"] for c in _calls if "/video/generations/" in c["url"]] == []
+    assert [c["url"] for c in _calls if f"/video/generations/{task}" in c["url"]] == []
     assert asyncio.run(app._media_job_get(jid))["status"] == "running"
 
     assert _save_config(api, hid, [{**_entry_of(hid), "enabled": True}]).status_code == 200


### PR DESCRIPTION
Main went red on the #14 merge commit (run 32456750694) with two failures in `test_media_mcp.py` that pass locally at the same commit.

**Cause, not a product bug:** `_media_sweep` advances every due running job in the store. Earlier tests in the file leave live jobs behind with `next_poll_at` 20s out. A fast local run finishes the file before they come due; a slow CI runner crosses the 20s line, a foreign job comes due, and its (correct) poll trips the two tests that assert **no** `/video/generations/` calls after deleting the agent / disabling the server. The failed run shows the leaked poll is for `task_2`, a job these tests never created.

**Fix:** capture the job's own `provider_task_id` and scope both assertions to it. The regression each test guards (sweeper carrying on for a deleted/disabled agent's job) is still covered exactly.

Test-only change; no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GknTsrWVoAbJe8qX7i8QA3