### PR TITLE
runner: support --plugin-dir and stdio MCP servers for Claude Code plugins

### DIFF
--- a/runner/server.py
+++ b/runner/server.py
@@ -367,22 +367,35 @@ def _mcp_name(s: str) -> str:
 
 
 def _write_mcp_config_claude(cwd: str, servers: list[dict]) -> str | None:
-    """Write a Claude Code .mcp.json for the enabled HTTP/SSE MCP servers. Returns its path
-    (passed via --mcp-config), or None if there are none."""
+    """Write a Claude Code .mcp.json for the enabled MCP servers. Returns its path
+    (passed via --mcp-config), or None if there are none.
+
+    Both remote (http/sse, keyed on `url`) and local (stdio, keyed on `command`) servers
+    are supported — stdio is the CLI's own default transport (`claude mcp add` defaults to
+    it, and a stdio entry is just `{"type": "stdio", "command": ..., "args": [...]}` in the
+    same .mcp.json this already writes), so accepting one here is not a new format, only a
+    second field this function previously never looked at."""
     entries: dict = {}
     for s in servers or []:
-        url = (s or {}).get("url")
-        if not url:
+        s = s or {}
+        name = _mcp_name(s.get("name") or s.get("id") or "mcp")
+        url = s.get("url")
+        command = s.get("command")
+        if url:
+            transport = (s.get("transport") or "http").lower()
+            entry = {"type": "sse" if transport == "sse" else "http", "url": url}
+            auth = s.get("auth")
+            if auth:  # bearer token (resolved by the gateway) -> Authorization header
+                hdr = auth if str(auth).lower().startswith("bearer ") else f"Bearer {auth}"
+                entry["headers"] = {"Authorization": hdr}
+            if isinstance(s.get("headers"), dict):
+                entry.setdefault("headers", {}).update(s["headers"])
+        elif command:
+            entry = {"type": "stdio", "command": command, "args": s.get("args") or []}
+            if isinstance(s.get("env"), dict):
+                entry["env"] = s["env"]
+        else:
             continue
-        name = _mcp_name((s or {}).get("name") or (s or {}).get("id") or "mcp")
-        transport = ((s or {}).get("transport") or "http").lower()
-        entry = {"type": "sse" if transport == "sse" else "http", "url": url}
-        auth = (s or {}).get("auth")
-        if auth:  # bearer token (resolved by the gateway) -> Authorization header
-            hdr = auth if str(auth).lower().startswith("bearer ") else f"Bearer {auth}"
-            entry["headers"] = {"Authorization": hdr}
-        if isinstance((s or {}).get("headers"), dict):
-            entry.setdefault("headers", {}).update(s["headers"])
         entries[name] = entry
     if not entries:
         return None
@@ -495,6 +508,70 @@ def _write_skills(cwd: str, skills: list[dict], backend: str = "claude") -> list
         if wrote:
             installed.append({"name": name, "desc": _skill_desc(files),
                               "entry": f"{entryroot}/{name}/SKILL.md"})
+    return installed
+
+
+# A plugin's hooks and CLI entry points are run directly by the shell, not by an interpreter
+# named on the command line — Claude Code's own convention (see any real plugin's hooks.json,
+# which invokes hooks/*.sh with no leading `sh`) requires the executable bit on disk. JSON has
+# no file-mode concept, so a caller may say so explicitly (`{"executable": true}` per file); where
+# it does not, the well-known locations a Claude Code plugin's own manifest format expects
+# scripts to live in — `bin/*` and `hooks/*.sh` — are treated as executable by convention, the
+# same convention the format itself already relies on. Verified the hard way: without this,
+# --plugin-dir loads the plugin's manifest fine and every hook invocation then fails with
+# "Permission denied" — a difference invisible until a hook actually fires.
+_PLUGIN_EXEC_PATTERNS = (re.compile(r"^bin/[^/]+$"), re.compile(r"^hooks/[^/]+\.sh$"))
+
+
+def _plugin_file_is_executable(rel: str, declared: bool | None) -> bool:
+    if declared is not None:
+        return bool(declared)
+    return any(p.match(rel) for p in _PLUGIN_EXEC_PATTERNS)
+
+
+def _write_plugins(cwd: str, plugins: list[dict]) -> list[str]:
+    """Materialize enabled Claude Code plugins into the workspace, one directory per plugin
+    under `.harness/plugins/<name>/`. Each plugin: {name, files:[{path, content|content_b64,
+    executable?}]}. Returns the absolute paths written, in order — the caller turns each into
+    one `--plugin-dir <path>` argument to `_build_claude`.
+
+    A single root, unlike skills: a plugin is loaded exclusively through --plugin-dir, so
+    there is no discovery path to also mirror it under, and a stray second copy under
+    .claude/ would risk Claude Code loading the same plugin twice."""
+    installed: list[str] = []
+    for pg in plugins or []:
+        pg = pg or {}
+        name = _mcp_name(pg.get("name") or pg.get("id") or "")
+        files = pg.get("files")
+        if not name or not files:
+            continue
+        root = _safe_join(cwd, f".harness/plugins/{name}")
+        if root is None:
+            continue
+        wrote = False
+        for f in files:
+            f = f or {}
+            rel = f.get("path")
+            content = f.get("content")
+            content_b64 = f.get("content_b64")
+            if not rel or (content is None and content_b64 is None):
+                continue
+            dest = _safe_join(str(root), rel)
+            if dest is None:
+                continue
+            try:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                if content_b64 is not None:
+                    dest.write_bytes(base64.b64decode(content_b64))
+                else:
+                    dest.write_text(content)
+                if _plugin_file_is_executable(rel, f.get("executable")):
+                    dest.chmod(dest.stat().st_mode | 0o111)
+                wrote = True
+            except Exception:  # noqa: BLE001
+                continue
+        if wrote:
+            installed.append(str(root))
     return installed
 
 
@@ -847,7 +924,7 @@ def _claude_thinking_env(model: str) -> dict:
 def _build_claude(provider: str, auth: Auth, model: str, prompt: str, max_turns: int,
                   cwd: str, env: dict, resume_session_id: str | None = None,
                   mcp_config: str | None = None, disallowed_tools: list[str] | None = None,
-                  partial: bool = False) -> list[str]:
+                  partial: bool = False, plugin_dirs: list[str] | None = None) -> list[str]:
     p = provider or "anthropic"
     if p not in CLAUDE_PROVIDERS:
         raise HTTPException(400, f"unknown claude provider '{p}' (one of {sorted(CLAUDE_PROVIDERS)})")
@@ -902,6 +979,8 @@ def _build_claude(provider: str, auth: Auth, model: str, prompt: str, max_turns:
         cmd.append("--include-partial-messages")
     if mcp_config:   # owner-attached MCP servers (.harness/mcp.json) — adds their tools this turn
         cmd += ["--mcp-config", mcp_config]
+    for pd in (plugin_dirs or []):   # owner-attached Claude Code plugins, one --plugin-dir each
+        cmd += ["--plugin-dir", pd]
     # Disabled tools go in settings.json, NOT on the command line. `--disallowedTools` is part of
     # the permission prompt system, and we pass --dangerously-skip-permissions (autonomous runs
     # cannot answer a prompt), which disables that system wholesale — so the flag was accepted,
@@ -2591,6 +2670,7 @@ class TurnReq(BaseModel):
     files: list[dict] | None = None        # caller-attached input files: [{filename, content_b64}]
     mcp_servers: list[dict] | None = None  # enabled MCP servers: [{name, url, transport?, auth?, headers?}]
     skills: list[dict] | None = None       # enabled skills: [{name, files:[{path, content|content_b64}]}]
+    plugins: list[dict] | None = None      # enabled Claude Code plugins: [{name, files:[{path, content|content_b64}]}]
     agent_doc: str | None = None           # harness instruction doc → AGENTS.md (codex) / CLAUDE.md (claude)
     skills_suppressed: list[str] | None = None  # built-in skill names to NOT mount (harness disabled them)
     tools_disabled: list[str] | None = None     # built-in tool names to disable (claude: --disallowedTools)
@@ -2705,9 +2785,11 @@ def turn(req: TurnReq, identifier: str = "") -> dict:
                         tools_disabled=req.tools_disabled, vision=bool(req.vision))
     else:
         mcp_config = _write_mcp_config_claude(cwd, req.mcp_servers)
+        plugin_dirs = _write_plugins(cwd, req.plugins)
         cmd = _build_claude(req.provider, auth, model, req.prompt, req.max_turns, cwd, env,
                             resume_session_id=req.resume_session_id, mcp_config=mcp_config,
-                            disallowed_tools=req.tools_disabled, partial=bool(req.partial_messages))
+                            disallowed_tools=req.tools_disabled, partial=bool(req.partial_messages),
+                            plugin_dirs=plugin_dirs)
     turn_id = "turn" + uuid.uuid4().hex
     with _turns_lock:
         # Double-check under the lock: a concurrent retry with the same key may have raced past the

--- a/runner/tests/test_claude_plugins.py
+++ b/runner/tests/test_claude_plugins.py
@@ -1,0 +1,149 @@
+"""Guard: a Claude Code plugin's own scripts must be executable once materialized, and its
+stdio-transport MCP servers must not be silently dropped.
+
+The first regression this pins was found live: `_write_plugins` wrote a plugin's
+`hooks/*.sh` and `bin/*` files with the default (non-executable) mode, so every hook
+invocation failed with "Permission denied" and the plugin's own MCP server (itself a
+shell script under `bin/`) never started — invisible until a real `--plugin-dir` turn
+actually tried to run one. Verified against a real Claude Code plugin end to end
+(`claude -p --plugin-dir ... --include-hook-events`): before the fix, hooks errored
+with exit_code 126 and the MCP server connection status was "failed"; after, hooks ran
+clean and the server connected.
+
+The second regression `_write_mcp_config_claude` used to have: it only ever emitted
+http/sse entries, silently skipping any server dict with no `url` — but `stdio` is the
+CLI's own default MCP transport (`claude mcp add` defaults to it), so a stdio server
+config (`{"command": ..., "args": [...]}`) was dropped with no error at all.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import server as rn  # noqa: E402
+
+
+def test_bin_files_are_written_executable(tmp_path):
+    plugin = {
+        "name": "demo",
+        "files": [
+            {"path": ".claude-plugin/plugin.json", "content": "{}"},
+            {"path": "bin/demo-run", "content": "#!/bin/sh\necho hi\n"},
+        ],
+    }
+    dirs = rn._write_plugins(str(tmp_path), [plugin])
+    assert len(dirs) == 1
+    entry = Path(dirs[0]) / "bin" / "demo-run"
+    assert entry.is_file()
+    assert entry.stat().st_mode & 0o111, "bin/demo-run was not written executable"
+
+
+def test_hook_scripts_are_written_executable(tmp_path):
+    plugin = {
+        "name": "demo",
+        "files": [
+            {"path": ".claude-plugin/plugin.json", "content": "{}"},
+            {"path": "hooks/notice.sh", "content": "#!/bin/sh\nexit 0\n"},
+        ],
+    }
+    dirs = rn._write_plugins(str(tmp_path), [plugin])
+    entry = Path(dirs[0]) / "hooks" / "notice.sh"
+    assert entry.stat().st_mode & 0o111, "hooks/notice.sh was not written executable"
+
+
+def test_ordinary_files_are_not_made_executable(tmp_path):
+    plugin = {
+        "name": "demo",
+        "files": [
+            {"path": ".claude-plugin/plugin.json", "content": "{}"},
+            {"path": "vesta/graph.py", "content": "x = 1\n"},
+        ],
+    }
+    dirs = rn._write_plugins(str(tmp_path), [plugin])
+    entry = Path(dirs[0]) / "vesta" / "graph.py"
+    assert not (entry.stat().st_mode & 0o111), "a plain source file was made executable"
+
+
+def test_a_declared_executable_flag_is_honoured_outside_the_known_paths(tmp_path):
+    plugin = {
+        "name": "demo",
+        "files": [
+            {"path": ".claude-plugin/plugin.json", "content": "{}"},
+            {"path": "scripts/setup", "content": "#!/bin/sh\n", "executable": True},
+        ],
+    }
+    dirs = rn._write_plugins(str(tmp_path), [plugin])
+    entry = Path(dirs[0]) / "scripts" / "setup"
+    assert entry.stat().st_mode & 0o111
+
+
+def test_multiple_plugins_land_in_their_own_directories(tmp_path):
+    plugins = [
+        {"name": "a", "files": [{"path": ".claude-plugin/plugin.json", "content": "{}"}]},
+        {"name": "b", "files": [{"path": ".claude-plugin/plugin.json", "content": "{}"}]},
+    ]
+    dirs = rn._write_plugins(str(tmp_path), plugins)
+    assert len(dirs) == 2
+    assert {Path(d).name for d in dirs} == {"a", "b"}
+
+
+def test_a_plugin_with_no_files_is_skipped(tmp_path):
+    dirs = rn._write_plugins(str(tmp_path), [{"name": "empty", "files": []}])
+    assert dirs == []
+
+
+def test_build_claude_appends_one_plugin_dir_flag_per_plugin():
+    cmd = rn._build_claude(
+        provider="anthropic", auth=rn.Auth(), model="claude-sonnet-5",
+        prompt="hi", max_turns=5, cwd="/tmp/ws", env={"HOME": "/tmp/ws/.harness/home"},
+        plugin_dirs=["/tmp/ws/.harness/plugins/a", "/tmp/ws/.harness/plugins/b"],
+    )
+    assert cmd.count("--plugin-dir") == 2
+    ia = cmd.index("--plugin-dir")
+    assert cmd[ia + 1] == "/tmp/ws/.harness/plugins/a"
+    ib = cmd.index("--plugin-dir", ia + 1)
+    assert cmd[ib + 1] == "/tmp/ws/.harness/plugins/b"
+
+
+def test_build_claude_with_no_plugins_appends_no_flag():
+    cmd = rn._build_claude(
+        provider="anthropic", auth=rn.Auth(), model="claude-sonnet-5",
+        prompt="hi", max_turns=5, cwd="/tmp/ws", env={"HOME": "/tmp/ws/.harness/home"},
+    )
+    assert "--plugin-dir" not in cmd
+
+
+def test_mcp_config_writes_a_stdio_entry(tmp_path):
+    path = rn._write_mcp_config_claude(
+        str(tmp_path), [{"name": "vesta", "command": "/plugin/bin/vesta-sidecar"}],
+    )
+    assert path is not None
+    import json
+    cfg = json.loads(Path(path).read_text())
+    entry = cfg["mcpServers"]["vesta"]
+    assert entry == {"type": "stdio", "command": "/plugin/bin/vesta-sidecar", "args": []}
+
+
+def test_mcp_config_stdio_entry_carries_args_and_env(tmp_path):
+    path = rn._write_mcp_config_claude(
+        str(tmp_path),
+        [{"name": "demo", "command": "npx", "args": ["my-mcp-server"], "env": {"KEY": "x"}}],
+    )
+    cfg_json = Path(path).read_text()
+    import json
+    entry = json.loads(cfg_json)["mcpServers"]["demo"]
+    assert entry["args"] == ["my-mcp-server"]
+    assert entry["env"] == {"KEY": "x"}
+
+
+def test_mcp_config_still_writes_http_entries_unchanged(tmp_path):
+    path = rn._write_mcp_config_claude(
+        str(tmp_path), [{"name": "remote", "url": "https://example.invalid/mcp"}],
+    )
+    import json
+    entry = json.loads(Path(path).read_text())["mcpServers"]["remote"]
+    assert entry == {"type": "http", "url": "https://example.invalid/mcp"}
+
+
+def test_mcp_config_with_neither_url_nor_command_is_skipped(tmp_path):
+    path = rn._write_mcp_config_claude(str(tmp_path), [{"name": "broken"}])
+    assert path is None


### PR DESCRIPTION
## What

`claude -p` (headless mode) already fully supports Claude Code's plugin format — commands, hooks, subagents, and a plugin's own MCP server — via `--plugin-dir`. The runner never passed that flag, and its `.mcp.json` writer only ever emitted `http`/`sse` MCP entries even though `stdio` is the CLI's own default transport. So a real Claude Code plugin (anything with `.claude-plugin/plugin.json`, `hooks/hooks.json`, a stdio MCP server) had no path into a harnessrouter-driven session, despite the underlying CLI already supporting it with zero changes needed there.

Verified directly against a real plugin, not inferred from docs: with `--plugin-dir` wired in, its MCP server connects (stdio), all its slash commands and subagents register, and its `UserPromptSubmit` hooks fire and return real output.

## What this PR adds

- `_write_mcp_config_claude` now also emits `stdio` entries (`{"command": ..., "args": [...], "env": {...}}`) when a server dict carries `command` instead of `url` — purely additive, existing http/sse behavior unchanged.
- `_write_plugins`, materializing enabled plugins into `.harness/plugins/<name>/` in the workspace, mirroring `_write_skills`'s existing mechanics.
- `_build_claude` gains a `plugin_dirs` parameter, appending one `--plugin-dir <path>` per plugin.
- `TurnReq.plugins: list[dict] | None`, wired through the existing claude-branch dispatch.

## A real bug this caught along the way

Materializing a plugin's files needs to preserve the executable bit on its `hooks/*.sh` and `bin/*` scripts — found live, not anticipated up front: without it, every hook invocation failed with `Permission denied` (`exit_code: 126`) and the plugin's own MCP server (itself usually a script under `bin/`) never started at all. Fixed by treating those two well-known locations as executable by convention (the same convention the plugin format's own manifest already relies on), with an explicit per-file `executable` override available if a caller wants to declare it.

## Scope

Runner only, Claude-Code-only (no changes to the codex/hermes/pi/dsh paths — plugins are a Claude Code CLI mechanic with no equivalent elsewhere). No gateway or UI changes in this PR — those are natural follow-ups (a `plugins` field on the Harness data model, a config-time validator, a UI section for uploading a plugin) once this lands, since the gateway/UI layer needs `TurnReq.plugins` to exist first. Also no protocol changes — this is intentionally a harnessrouter-CE-only extension, not a UHP addition, since `plugins` is Claude-Code-specific and the protocol's harness capability list is otherwise closed.

## Testing

- New `runner/tests/test_claude_plugins.py` (12 tests): executable-bit handling (the three known-path cases, the explicit-override case, the  don't-touch-ordinary-files case), multi-plugin isolation, empty-plugin  skip, `--plugin-dir` flag construction, and the new stdio MCP branch
- Full existing runner suite passes unchanged (61 existing + 12 new = 73).
- Manually verified end to end against a real ~150-file Claude Code  plugin: materialized via `_write_plugins`, ran the exact command  `_build_claude` generates as a real subprocess in an isolated `$HOME`  (matching the runner's own redirect), confirmed via `claude`'s own debug  log that its MCP server connected (`stdio`, ~12s cold start — see note  below) with all tools/prompts/resources, and that hooks fired successfully.
  
## One thing worth flagging, not solved here

A plugin with a self-installing dependency bootstrap (the one tested here builds its own Python venv on first use) incurs a one-time cold-start cost on first MCP connection in a fresh workspace — comfortably inside Claude Code's own 30s MCP-connect timeout in testing, but worth knowing if a harness owner's turn timeout is set aggressively low. Not something to fix in this PR; noting it for whoever picks up the gateway/UI follow-up.