### PR TITLE
site: drop the ignoreCommand that failed the first Vercel build

### DIFF
--- a/protocol/site/.gitignore
+++ b/protocol/site/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 .env*
+.venv/

--- a/protocol/site/build.sh
+++ b/protocol/site/build.sh
@@ -5,5 +5,9 @@
 # so it runs identically from any working directory.
 set -euo pipefail
 cd "$(dirname "$0")"
-python3 -m pip install --quiet --requirement requirements.txt
-python3 build.py
+# Install into a throwaway virtualenv rather than the system Python. Vercel's build image ships a
+# uv-managed, PEP 668 "externally managed" Python that refuses `pip install` into it; a venv sidesteps
+# that and behaves identically on GitHub CI, so one script works in both places.
+python3 -m venv .venv
+.venv/bin/python -m pip install --quiet --requirement requirements.txt
+.venv/bin/python build.py

--- a/protocol/vercel.json
+++ b/protocol/vercel.json
@@ -3,7 +3,6 @@
   "framework": null,
   "buildCommand": "bash site/build.sh",
   "outputDirectory": "site/dist",
-  "ignoreCommand": "git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- .",
   "cleanUrls": true,
   "trailingSlash": false,
   "redirects": [


### PR DESCRIPTION
The first Git deployment of the spec site to Vercel failed:

```
Command failed with exit code 128: git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" -- .
fatal: bad revision ""
```

On the first Git deployment there is no `$VERCEL_GIT_PREVIOUS_SHA`, so the ignore command hits `git diff "" <sha>` → exit 128. Vercel treats a non-0/1 exit from the ignore command as a **build failure**, not "build anyway" — so the deploy errored (production was untouched, since a failed build never promotes). The custom diff is also defeated by Vercel's shallow clone, which often lacks the previous SHA.

Fix: remove the custom `ignoreCommand` and rely on Vercel's native "skip when the root directory is unchanged" setting, which uses Vercel's own git metadata and is monorepo-safe. `buildCommand`/`outputDirectory` are unchanged, so the CI `site` job's config assertion still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)