### PR TITLE
conformance: cover session sharing, the one Full chapter nothing tests

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -3460,9 +3460,18 @@ async def delete_trace(sid: str, request: Request) -> dict:
     try:
         # Mark deleted but DON'T blank trace_blob — a blank prefix silently disables the trace if the
         # session is later resumed (the prefix is deterministic from created_at_inv anyway).
-        await _vg_upsert("HarnessSession", sid, {"status": "deleted"})
+        #
+        # `shared: "0"` is part of the tombstone, not hygiene. The share resolver matches on
+        # {share_token, shared: "1"} and never looks at status, so a deleted session's link kept
+        # resolving — and the turns behind it are rebuilt from response records, which this
+        # function does not remove. Verified live: DELETE answered 200 and the share link went on
+        # serving the full conversation. Sessions §6 says deletion MUST make the session
+        # unreadable, and the published link is the reader its owner is least likely to remember.
+        await _vg_upsert("HarnessSession", sid, {"status": "deleted", "shared": "0"})
     except Exception:  # noqa: BLE001
         pass
+    _SHARE_STATE_CACHE.pop(sid, None)
+    _SHARE_TOKEN_CACHE.clear()
     _session_trace.pop(sid, None)
     return {"id": sid, "object": "session", "deleted": True}
 
@@ -6542,26 +6551,62 @@ async def artifact_by_path(sid: str, path: str, request: Request) -> Response:
 
 
 class ShareBody(BaseModel):
-    enabled: bool
+    enabled: bool = True
+
+
+def _share_out(enabled: bool, token: str) -> dict:
+    """The share object, self-describing. Sessions §5 names the mint endpoint but not where the
+    view is served, so the object says so itself: `url` is where this share reads back, relative
+    to whatever base the caller is already using — the gateway cannot know its public origin (the
+    console proxy deliberately strips Host and x-forwarded-*), and a path survives every fronting
+    (direct, or via /api/harness which relays /share/* through). `id` is the token because the
+    token IS the share's identity; a conformance probe that presents it as an API bearer must be
+    refused, and giving it a second name would only hide that from the check."""
+    out = {"object": "session.share", "enabled": enabled, "token": token}
+    if token:
+        out["id"] = token
+        out["url"] = f"/share/{token}"
+    return out
 
 
 @app.post("/v1/sessions/{sid}/share")
-async def set_session_share(sid: str, body: ShareBody, request: Request) -> dict:
+async def set_session_share(sid: str, request: Request, body: ShareBody | None = None) -> dict:
+    """Publish (or with enabled:false, revoke) the read-only shared view of a session.
+
+    The body is OPTIONAL, defaulting to enabled. Sessions §5 documents `POST .../share` with no
+    body — publishing is the whole meaning of the request — and requiring `{"enabled": true}`
+    made this endpoint 422 a caller speaking the specification's own dialect (the conformance
+    suite among them)."""
     p = await _principal(request)
     v = await _vertex_get(sid)
     if not v or str(v.get("tenant") or "") != p.get("org"):
         raise uhp_error(404, "session_not_found", "No session with that id.", "session_id")
-    if body.enabled:
+    if body is None or body.enabled:
         token = str(v.get("share_token") or "") or ("shr" + uuid.uuid4().hex)
         await _vertex_upsert(sid, {"share_token": token, "shared": "1",
                                    "shared_at": str(time.time())})
         _SHARE_STATE_CACHE.pop(sid, None)
         _SHARE_TOKEN_CACHE.clear()
-        return {"enabled": True, "token": token}
+        return _share_out(True, token)
     await _vertex_upsert(sid, {"shared": "0"})
     _SHARE_STATE_CACHE.pop(sid, None)
     _SHARE_TOKEN_CACHE.clear()
-    return {"enabled": False, "token": str(v.get("share_token") or "")}
+    return _share_out(False, str(v.get("share_token") or ""))
+
+
+@app.delete("/v1/sessions/{sid}/share")
+async def revoke_session_share(sid: str, request: Request) -> dict:
+    """Revocation, at the address of the thing being revoked. §5 says a share MUST be revocable
+    and names no path; DELETE on the share endpoint is the reading a client tries first, and it
+    was answering 405 while the real revocation hid inside POST {"enabled": false}. Both work."""
+    p = await _principal(request)
+    v = await _vertex_get(sid)
+    if not v or str(v.get("tenant") or "") != p.get("org"):
+        raise uhp_error(404, "session_not_found", "No session with that id.", "session_id")
+    await _vertex_upsert(sid, {"shared": "0"})
+    _SHARE_STATE_CACHE.pop(sid, None)
+    _SHARE_TOKEN_CACHE.clear()
+    return _share_out(False, str(v.get("share_token") or "")) | {"deleted": True}
 
 
 @app.get("/v1/sessions/{sid}/share")
@@ -6570,7 +6615,7 @@ async def get_session_share(sid: str, request: Request) -> dict:
     v = await _vertex_get(sid)
     if not v or str(v.get("tenant") or "") != p.get("org"):
         raise uhp_error(404, "session_not_found", "No session with that id.", "session_id")
-    return {"enabled": str(v.get("shared") or "") == "1", "token": str(v.get("share_token") or "")}
+    return _share_out(str(v.get("shared") or "") == "1", str(v.get("share_token") or ""))
 
 
 async def _share_sid(token: str) -> str | None:
@@ -6595,6 +6640,14 @@ async def _share_sid(token: str) -> str | None:
 
 _SHARE_META_FIELDS = ("session_id", "title", "status", "model", "backend",
                       "harness_id", "harness_name", "event_count", "elapsed", "finished_at")
+
+
+@app.get("/share/{token}")
+async def share_view(token: str) -> dict:
+    """The shared view's root: what the published URL opens. The subroutes carry the pieces
+    (meta / turns / files); this is the object a link-holder lands on, and the address every
+    read-only guarantee in Sessions §5 is measured at."""
+    return {"object": "session.shared", **(await share_meta(token))}
 
 
 @app.get("/share/{token}/meta")

--- a/gateway/tests/test_share_selfhost.py
+++ b/gateway/tests/test_share_selfhost.py
@@ -58,3 +58,64 @@ def test_switching_sharing_off_revokes_the_link(api):
 def test_an_unknown_token_is_not_found(api):
     assert asyncio.run(gw._share_sid("shr" + "0" * 32)) is None
     assert api.get("/share/shr" + "0" * 32 + "/meta").status_code == 404
+
+
+def test_a_bodyless_post_publishes_the_share(api):
+    """Sessions §5 documents `POST .../share` with no body — publishing is the request's whole
+    meaning — and this endpoint 422'd that dialect, which is how the entire conformance R-series
+    skipped against the reference server."""
+    sid = "hsessshare" + os.urandom(4).hex()
+    _session(sid)
+    r = api.post(f"/v1/sessions/{sid}/share")
+    assert r.status_code == 200, r.text
+    d = r.json()
+    assert d["enabled"] is True and d["token"]
+    assert d["id"] == d["token"], "the token is the share's identity, under one name"
+    assert d["url"] == f"/share/{d['token']}", "the object must say where its view is served"
+    assert api.get(f"/v1/sessions/{sid}/share").json()["url"] == d["url"], (
+        "GET must report the same link POST published")
+
+
+def test_the_published_url_opens_with_no_credential(api):
+    sid = "hsessshare" + os.urandom(4).hex()
+    _session(sid)
+    url = api.post(f"/v1/sessions/{sid}/share").json()["url"]
+    r = api.get(url)     # no auth beyond the link itself: the token is the credential
+    assert r.status_code == 200, r.text
+    assert r.json()["object"] == "session.shared"
+    assert r.json()["session_id"] == sid
+
+
+def test_delete_on_the_share_endpoint_revokes(api):
+    """§5 requires revocability and names no path. DELETE on the share endpoint is the reading a
+    client tries first, and it answered 405 while revocation hid inside POST {"enabled": false}."""
+    sid = "hsessshare" + os.urandom(4).hex()
+    _session(sid)
+    url = api.post(f"/v1/sessions/{sid}/share").json()["url"]
+    assert api.get(url).status_code == 200
+    r = api.delete(f"/v1/sessions/{sid}/share")
+    assert r.status_code == 200 and r.json()["enabled"] is False
+    assert api.get(url).status_code == 404, "a revoked link must stop resolving"
+
+
+def test_deleting_the_session_takes_its_share_with_it(api, monkeypatch):
+    """The R-07 defect, verified live before this fix: DELETE /v1/traces answered 200 and the
+    share link went on serving the full conversation, because the resolver matches on
+    {share_token, shared: "1"} and the tombstone never touched `shared` — while the turns behind
+    the view are rebuilt from response records, which deletion does not remove. Sessions §6:
+    deletion MUST make the session unreadable, and the published link is the reader its owner is
+    least likely to remember."""
+    sid = "hsessshare" + os.urandom(4).hex()
+    _session(sid)
+
+    async def owned(request, s):
+        return ORG, {"id": s, "tenant": ORG}
+    monkeypatch.setattr(gw, "_owned_session", owned)
+
+    url = api.post(f"/v1/sessions/{sid}/share").json()["url"]
+    assert api.get(url).status_code == 200
+    assert api.delete(f"/v1/traces/{sid}").status_code == 200
+    assert api.get(url).status_code == 404, "a deleted session's share link must die with it"
+    assert api.get(url + "/turns").status_code == 404, (
+        "the turns behind the view are rebuilt from response records deletion does not remove — "
+        "the resolver is the only gate, so it must refuse")

--- a/protocol/conformance/README.md
+++ b/protocol/conformance/README.md
@@ -113,8 +113,14 @@ a live instance on 2026-08-11:
     CONFORMANT — UHP 2026-08-11 (full)
 ```
 
-That run predates the `R-` series, so it is a 52-check result and has not been re-measured
-against the 59.
+That run predates the `R-` series, so it is a 52-check result. The R-series itself has been
+measured against the reference implementation directly: at the commit this note ships in,
+`R-01`…`R-07` all pass against a live self-hosted instance. Getting there took changes on both
+sides, which is the strongest argument this suite has for itself — against the reference as it
+stood, all seven checks skipped (its share dialect wanted `{"enabled": true}` and published no
+view URL), and behind those skips sat a real Sessions §6 violation: a session's share link kept
+serving the full conversation after `DELETE /v1/traces/{id}`, verified live before the fix. A
+suite that had shipped happy-path checks would have called that server conformant.
 
 The suite is developed against that implementation, which is exactly why the specification says
 conformance is defined by the suite and not by the implementation: anything the reference does that

--- a/protocol/conformance/README.md
+++ b/protocol/conformance/README.md
@@ -37,13 +37,13 @@ anything that only inspects a schema.
 
 ## What it checks
 
-52 checks across three classes.
+59 checks across three classes.
 
 | Class | Checks | Covers |
 |---|---|---|
 | **Core** | 37 | Discovery, version negotiation, authentication, the error envelope, harnesses, models, task execution (streaming and not), the event stream, sessions, cancellation |
 | **Extended** | +8 | Session listing and inspection, file input, artifacts, download headers, path-traversal probes |
-| **Full** | +7 | Harness create / update / delete, refusal of an unsupported base, skill-folder round trip, MCP and disabled-tool persistence |
+| **Full** | +14 | Harness create / update / delete, refusal of an unsupported base, skill-folder round trip, MCP and disabled-tool persistence, session sharing |
 
 Every check names the section of the specification it enforces, so a failure points at the sentence
 it violates rather than at a test name.
@@ -64,6 +64,15 @@ A few of them are worth calling out, because they catch things a schema check ne
   own origin.
 - **X-08** — artifact ids do not traverse out of their container. Probes for `../` and its
   percent-encoded form.
+- **R-01…R-07** — session sharing, which is mostly a set of refusals. Sessions §5 requires that a
+  shared view be read-only, revocable, and free of credentials, and a check that merely opens a
+  link and reads the conversation passes against a server that also lets that link continue the
+  task, cancel the run, or upload into the working directory. §5 makes sharing optional, so these
+  skip rather than fail on a server that does not implement it; and because §5 names no endpoint
+  for the view or for revocation, they discover both from what the server returned and skip with
+  the missing sentence as the reason. `tests/test_session_sharing_checks.py` runs the series
+  against a deliberately wrong server, one defect at a time, so each of them is known to fail on
+  the mistake it describes.
 - **F-03/F-04** — a skill is a folder, and it survives an unrelated edit. A server that stores only
   `SKILL.md`, or that empties a bundle when the harness is renamed, passes every other check: the
   config still looks right, and the loss only shows up later as an agent behaving oddly.
@@ -103,6 +112,9 @@ a live instance on 2026-08-11:
     52/52 passed · 0 failed · 0 skipped · 0 errored
     CONFORMANT — UHP 2026-08-11 (full)
 ```
+
+That run predates the `R-` series, so it is a 52-check result and has not been re-measured
+against the 59.
 
 The suite is developed against that implementation, which is exactly why the specification says
 conformance is defined by the suite and not by the implementation: anything the reference does that

--- a/protocol/conformance/tests/share_defect_stub.py
+++ b/protocol/conformance/tests/share_defect_stub.py
@@ -1,0 +1,212 @@
+"""A deliberately wrong UHP server, with one toggleable defect per rule in Sessions §5.
+
+The R-series checks what a shared view REFUSES, and a check that only ever passes proves
+nothing about a refusal. So this stub implements just enough of the protocol for those checks
+to run, and takes a DEFECT environment variable naming one thing to get wrong.
+test_session_sharing_checks.py drives it once per defect and asserts the diagonal.
+
+It answers every task itself, so the matrix needs no credentials, no network and no agent
+tokens, and finishes in seconds.
+
+    DEFECT=revoke_lies PORT=8931 python3 share_defect_stub.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+DEFECT = os.environ.get("DEFECT", "none")
+PORT = int(os.environ.get("PORT", "8931"))
+KEY = "stub-key"
+
+DEFECTS = {
+    "none",
+    "view_needs_auth",       # the "published" view demands the owner's credential
+    "get_share_disagrees",   # GET /share reports a different link from the one POST minted
+    "share_id_is_token",     # the share id authenticates the real API
+    "view_accepts_writes",   # the shared view accepts a write from a link holder
+    "leaks_credentials",     # the view carries the harness's MCP auth and headers
+    "revoke_lies",           # revocation answers 200 and revokes nothing
+    "multi_mint",            # every POST mints a new link; revocation kills only the newest
+    "share_outlives_session",  # the link survives the deletion of its session
+}
+assert DEFECT in DEFECTS, f"unknown defect {DEFECT!r}; one of {sorted(DEFECTS)}"
+
+SESSIONS: dict[str, dict] = {}          # session_id -> {"deleted": bool}
+SHARES: dict[str, str] = {}             # share_id   -> session_id
+BY_SESSION: dict[str, list[str]] = {}   # session_id -> [share_id] in mint order
+
+
+def view_of(session_id: str) -> dict:
+    v = {"object": "session.shared", "session": {"id": session_id, "object": "session"},
+         "harness": {"id": "h1", "name": "stub", "base": "stub"}}
+    if DEFECT == "leaks_credentials":
+        v["harness"]["mcpServers"] = [{"name": "internal", "url": "https://mcp.example.invalid",
+                                       "auth": {"type": "bearer", "token": "sk-live-not-yours"},
+                                       "headers": {"x-api-key": "sk-live-not-yours"}}]
+    return v
+
+
+class H(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a):  # quiet
+        pass
+
+    # ── plumbing ──────────────────────────────────────────────────────────────────────
+    def send(self, status: int, payload=None):
+        body = b"" if payload is None else json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("uhp-version", "2026-08-11")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def bearer(self) -> str:
+        return (self.headers.get("authorization") or "").removeprefix("Bearer ").strip()
+
+    def authed(self) -> bool:
+        tok = self.bearer()
+        if tok == KEY:
+            return True
+        return DEFECT == "share_id_is_token" and tok in SHARES
+
+    def read_body(self):
+        n = int(self.headers.get("content-length") or 0)
+        if n:
+            self.rfile.read(n)
+
+    def path_parts(self):
+        return [p for p in urlsplit(self.path).path.split("/") if p]
+
+    # ── routing ───────────────────────────────────────────────────────────────────────
+    def do_GET(self):
+        self.route("GET")
+
+    def do_POST(self):
+        self.route("POST")
+
+    def do_PUT(self):
+        self.route("PUT")
+
+    def do_PATCH(self):
+        self.route("PATCH")
+
+    def do_DELETE(self):
+        self.route("DELETE")
+
+    def route(self, method: str):
+        self.read_body()
+        p = self.path_parts()
+
+        # Discovery, unauthenticated.
+        if method == "GET" and p == ["v1", "uhp"]:
+            return self.send(200, {
+                "object": "uhp.discovery", "versions": ["2026-08-11"],
+                "default_version": "2026-08-11", "conformance_class": "full",
+                "capabilities": {"streaming": True, "sessions": True, "cancellation": True,
+                                 "files_input": True, "files_output": True,
+                                 "session_listing": True, "harness_management": True,
+                                 "session_sharing": True}})
+
+        # The shared view: reached by whoever holds the link.
+        if p[:2] == ["v1", "shares"] and len(p) >= 3:
+            return self.shared_view(method, p[2])
+
+        # Everything else needs the API credential.
+        if not self.authed():
+            return self.send(401, {"error": {"code": "unauthorized", "message": "no credential"}})
+
+        if method == "GET" and p == ["v1", "harnesses"]:
+            return self.send(200, {"harnesses": [{"id": "h1", "name": "stub", "base": "stub"}]})
+        if method == "GET" and p in (["v1", "sessions"], ["v1", "responses"]):
+            return self.send(200, {p[1]: []})
+        if method == "POST" and p == ["v1", "responses"]:
+            sid = f"sess_{uuid.uuid4().hex[:10]}"
+            SESSIONS[sid] = {"deleted": False}
+            return self.send(200, {
+                "id": f"resp_{uuid.uuid4().hex[:10]}", "object": "response", "status": "completed",
+                "model": "stub-1", "usage": None, "created_at": int(time.time()),
+                "output": [{"type": "message", "role": "assistant",
+                            "content": [{"type": "output_text", "text": "ok"}]}],
+                "metadata": {"session_id": sid, "harness_id": "h1"}})
+        if p[:2] == ["v1", "sessions"] and len(p) >= 4 and p[3] == "share":
+            return self.share_endpoint(method, p[2], p[4:])
+        if method == "DELETE" and p[:2] == ["v1", "traces"] and len(p) == 3:
+            return self.delete_session(p[2])
+        return self.send(404, {"error": {"code": "not_found", "message": "no such endpoint"}})
+
+    # ── Sessions §5 ───────────────────────────────────────────────────────────────────
+    def share_endpoint(self, method: str, sid: str, rest: list[str]):
+        if sid not in SESSIONS or SESSIONS[sid]["deleted"]:
+            return self.send(404, {"error": {"code": "session_not_found", "message": "gone"}})
+        existing = BY_SESSION.get(sid) or []
+
+        if method == "POST" and not rest:
+            if existing and DEFECT != "multi_mint":
+                return self.send(200, self.share_body(existing[-1], sid))
+            share_id = f"share_{uuid.uuid4().hex[:12]}"
+            SHARES[share_id] = sid
+            BY_SESSION.setdefault(sid, []).append(share_id)
+            return self.send(200, self.share_body(share_id, sid))
+
+        if method == "GET" and not rest:
+            if not existing:
+                return self.send(404, {"error": {"code": "share_not_found", "message": "none"}})
+            if DEFECT == "get_share_disagrees":
+                return self.send(200, {**self.share_body(existing[-1], sid),
+                                       "url": f"http://127.0.0.1:{PORT}/v1/shares/share_elsewhere"})
+            return self.send(200, self.share_body(existing[-1], sid))
+
+        if method == "DELETE" and not rest:
+            if not existing:
+                return self.send(404, {"error": {"code": "share_not_found", "message": "none"}})
+            newest = existing[-1]
+            if DEFECT != "revoke_lies":
+                doomed = [newest] if DEFECT == "multi_mint" else list(existing)
+                for s in doomed:
+                    SHARES.pop(s, None)
+                BY_SESSION[sid] = [s for s in existing if s not in doomed]
+            return self.send(200, {"id": newest, "object": "session.share", "deleted": True})
+
+        return self.send(405, {"error": {"code": "method_not_allowed", "message": "no"}})
+
+    def share_body(self, share_id: str, sid: str) -> dict:
+        return {"id": share_id, "object": "session.share", "session_id": sid,
+                "url": f"http://127.0.0.1:{PORT}/v1/shares/{share_id}",
+                "created_at": int(time.time())}
+
+    def shared_view(self, method: str, share_id: str):
+        if DEFECT == "view_needs_auth" and self.bearer() != KEY:
+            return self.send(401, {"error": {"code": "unauthorized", "message": "sign in"}})
+        sid = SHARES.get(share_id)
+        if not sid:
+            return self.send(404, {"error": {"code": "not_found", "message": "no such share"}})
+        if SESSIONS.get(sid, {}).get("deleted") and DEFECT != "share_outlives_session":
+            return self.send(404, {"error": {"code": "not_found", "message": "no such share"}})
+        if method == "GET":
+            return self.send(200, view_of(sid))
+        if DEFECT == "view_accepts_writes":
+            return self.send(200, {"ok": True})
+        return self.send(405, {"error": {"code": "method_not_allowed", "message": "read-only"}})
+
+    # ── Sessions §6 ───────────────────────────────────────────────────────────────────
+    def delete_session(self, sid: str):
+        if sid not in SESSIONS:
+            return self.send(404, {"error": {"code": "session_not_found", "message": "gone"}})
+        SESSIONS[sid]["deleted"] = True
+        if DEFECT != "share_outlives_session":
+            for s in BY_SESSION.pop(sid, []):
+                SHARES.pop(s, None)
+        return self.send(200, {"id": sid, "object": "session", "deleted": True})
+
+
+if __name__ == "__main__":
+    print(f"stub: defect={DEFECT} port={PORT}", flush=True)
+    ThreadingHTTPServer(("127.0.0.1", PORT), H).serve_forever()

--- a/protocol/conformance/tests/share_defect_stub.py
+++ b/protocol/conformance/tests/share_defect_stub.py
@@ -20,6 +20,12 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlsplit
 
 DEFECT = os.environ.get("DEFECT", "none")
+# plain    — §5's literal dialect: a bodyless POST publishes, DELETE on the endpoint revokes.
+# enabled  — the toggle dialect the reference implementation speaks: the body carries the target
+#            state, an empty body is a validation error, and revocation is {"enabled": false}.
+# The R-series must drive both, so the matrix runs both.
+DIALECT = os.environ.get("DIALECT", "plain")
+assert DIALECT in ("plain", "enabled"), f"unknown dialect {DIALECT!r}"
 PORT = int(os.environ.get("PORT", "8931"))
 KEY = "stub-key"
 
@@ -77,10 +83,9 @@ class H(BaseHTTPRequestHandler):
             return True
         return DEFECT == "share_id_is_token" and tok in SHARES
 
-    def read_body(self):
+    def read_body(self) -> bytes:
         n = int(self.headers.get("content-length") or 0)
-        if n:
-            self.rfile.read(n)
+        return self.rfile.read(n) if n else b""
 
     def path_parts(self):
         return [p for p in urlsplit(self.path).path.split("/") if p]
@@ -102,7 +107,7 @@ class H(BaseHTTPRequestHandler):
         self.route("DELETE")
 
     def route(self, method: str):
-        self.read_body()
+        self.body = self.read_body()
         p = self.path_parts()
 
         # Discovery, unauthenticated.
@@ -149,6 +154,17 @@ class H(BaseHTTPRequestHandler):
         existing = BY_SESSION.get(sid) or []
 
         if method == "POST" and not rest:
+            if DIALECT == "enabled":
+                try:
+                    body = json.loads(self.body or b"")
+                except Exception:
+                    body = None
+                if not isinstance(body, dict) or "enabled" not in body:
+                    return self.send(422, {"detail": [{"type": "missing",
+                                                       "loc": ["body", "enabled"],
+                                                       "msg": "Field required"}]})
+                if body["enabled"] is False:
+                    return self.revoke(sid, existing)
             if existing and DEFECT != "multi_mint":
                 return self.send(200, self.share_body(existing[-1], sid))
             share_id = f"share_{uuid.uuid4().hex[:12]}"
@@ -165,22 +181,35 @@ class H(BaseHTTPRequestHandler):
             return self.send(200, self.share_body(existing[-1], sid))
 
         if method == "DELETE" and not rest:
+            if DIALECT == "enabled":
+                # This dialect's revocation lives in the POST body, nowhere else — which is
+                # exactly the shape R-06's last attempt exists for.
+                return self.send(405, {"error": {"code": "method_not_allowed", "message": "no"}})
             if not existing:
                 return self.send(404, {"error": {"code": "share_not_found", "message": "none"}})
-            newest = existing[-1]
-            if DEFECT != "revoke_lies":
-                doomed = [newest] if DEFECT == "multi_mint" else list(existing)
-                for s in doomed:
-                    SHARES.pop(s, None)
-                BY_SESSION[sid] = [s for s in existing if s not in doomed]
-            return self.send(200, {"id": newest, "object": "session.share", "deleted": True})
+            return self.revoke(sid, existing)
 
         return self.send(405, {"error": {"code": "method_not_allowed", "message": "no"}})
 
+    def revoke(self, sid: str, existing: list[str]):
+        newest = existing[-1] if existing else ""
+        if DEFECT != "revoke_lies":
+            doomed = [newest] if DEFECT == "multi_mint" else list(existing)
+            for s in doomed:
+                SHARES.pop(s, None)
+            BY_SESSION[sid] = [s for s in existing if s not in doomed]
+        out = {"id": newest, "object": "session.share", "deleted": True}
+        if DIALECT == "enabled":
+            out["enabled"] = False
+        return self.send(200, out)
+
     def share_body(self, share_id: str, sid: str) -> dict:
-        return {"id": share_id, "object": "session.share", "session_id": sid,
-                "url": f"http://127.0.0.1:{PORT}/v1/shares/{share_id}",
-                "created_at": int(time.time())}
+        out = {"id": share_id, "object": "session.share", "session_id": sid,
+               "url": f"http://127.0.0.1:{PORT}/v1/shares/{share_id}",
+               "created_at": int(time.time())}
+        if DIALECT == "enabled":
+            out["enabled"] = True
+        return out
 
     def shared_view(self, method: str, share_id: str):
         if DEFECT == "view_needs_auth" and self.bearer() != KEY:
@@ -208,5 +237,5 @@ class H(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    print(f"stub: defect={DEFECT} port={PORT}", flush=True)
+    print(f"stub: defect={DEFECT} dialect={DIALECT} port={PORT}", flush=True)
     ThreadingHTTPServer(("127.0.0.1", PORT), H).serve_forever()

--- a/protocol/conformance/tests/test_session_sharing_checks.py
+++ b/protocol/conformance/tests/test_session_sharing_checks.py
@@ -1,0 +1,121 @@
+"""The R-series is tested the way it asks servers to be tested: by being shown to fail.
+
+Sessions §5 is mostly a list of refusals, and a check that only ever passes cannot tell a
+server that refuses from one that does not — D-05 passed against real servers for months while
+being vacuous, which is the failure this file exists to avoid repeating.
+
+So every R- check is run against a deliberately wrong server (share_defect_stub.py) carrying
+one defect at a time. Each defect must be caught by the check that claims to cover it, and a
+clean server must pass all seven. The stub answers every task itself, so this needs no
+credentials, no network and no agent tokens.
+"""
+from __future__ import annotations
+
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from uhp_conformance import checks  # noqa: F401 — importing populates the registry
+from uhp_conformance.client import Client
+from uhp_conformance.context import Context
+from uhp_conformance.registry import REGISTRY, Outcome
+
+STUB = pathlib.Path(__file__).parent / "share_defect_stub.py"
+
+# Each defect, and the check whose message names exactly that mistake.
+CAUGHT_BY = {
+    "view_needs_auth": "R-01",
+    "get_share_disagrees": "R-02",
+    "share_id_is_token": "R-03",
+    "view_accepts_writes": "R-04",
+    "leaks_credentials": "R-05",
+    "revoke_lies": "R-06",
+    "multi_mint": "R-06",
+    "share_outlives_session": "R-07",
+}
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _run_series(defect: str) -> dict[str, Outcome]:
+    """Every R- check against a stub carrying `defect`, in registration order."""
+    port = _free_port()
+    srv = subprocess.Popen([sys.executable, str(STUB)],
+                           env={"DEFECT": defect, "PORT": str(port), "PATH": "/usr/bin:/bin"},
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/v1/uhp", timeout=1).read()
+                break
+            except (urllib.error.URLError, OSError):
+                time.sleep(0.05)
+        else:
+            pytest.fail(f"the stub did not start for defect {defect!r}")
+
+        # A fresh context per defect: the checks cache the share they minted, and a cache carried
+        # between servers would test the previous one.
+        ctx = Context(client=Client(f"http://127.0.0.1:{port}", "stub-key"), task_timeout=30.0)
+        return {c.id: c.run(ctx).outcome for c in REGISTRY if c.id.startswith("R-")}
+    finally:
+        srv.terminate()
+        srv.wait(timeout=5)
+
+
+def test_the_series_is_registered_at_full():
+    ids = [c.id for c in REGISTRY if c.id.startswith("R-")]
+    assert ids == [f"R-0{i}" for i in range(1, 8)]
+    assert {c.cls for c in REGISTRY if c.id.startswith("R-")} == {"full"}
+
+
+def test_a_conformant_server_passes_every_check():
+    out = _run_series("none")
+    assert all(o is Outcome.PASS for o in out.values()), out
+
+
+@pytest.mark.parametrize("defect,expected", sorted(CAUGHT_BY.items()))
+def test_each_defect_is_caught_by_its_own_check(defect, expected):
+    out = _run_series(defect)
+    assert out[expected] is Outcome.FAIL, (
+        f"{defect!r} was not caught by {expected}: {out}")
+
+
+@pytest.mark.parametrize("defect,expected", sorted(CAUGHT_BY.items()))
+def test_no_other_check_reports_a_failure_for_that_defect(defect, expected):
+    """One defect, one red check.
+
+    A second failure elsewhere is not extra safety — it is a misleading diagnosis, and it is how
+    a reviewer ends up chasing the wrong sentence of the specification. Where a defect genuinely
+    makes another check unrunnable (a view that never resolved cannot be observed to stop
+    resolving), the check is expected to skip rather than to guess.
+    """
+    out = _run_series(defect)
+    also_failed = [i for i, o in out.items() if o is Outcome.FAIL and i != expected]
+    assert not also_failed, f"{defect!r} also failed {also_failed}, which diagnoses one bug twice"
+
+
+def test_a_view_that_never_resolved_makes_the_later_checks_skip():
+    out = _run_series("view_needs_auth")
+    assert out["R-01"] is Outcome.FAIL
+    for i in ("R-04", "R-05", "R-06", "R-07"):
+        assert out[i] is Outcome.SKIP, (
+            f"{i} should skip when the view never resolved, got {out[i]}: 'stops resolving' and "
+            "'never resolved' are indistinguishable there")
+
+
+def test_no_check_errors_on_any_defect():
+    """An ERROR is a bug in the suite. It must never be how a defect gets reported."""
+    for defect in ["none", *CAUGHT_BY]:
+        out = _run_series(defect)
+        assert Outcome.ERROR not in out.values(), f"{defect}: {out}"

--- a/protocol/conformance/tests/test_session_sharing_checks.py
+++ b/protocol/conformance/tests/test_session_sharing_checks.py
@@ -47,11 +47,12 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
-def _run_series(defect: str) -> dict[str, Outcome]:
+def _run_series(defect: str, dialect: str = "plain") -> dict[str, Outcome]:
     """Every R- check against a stub carrying `defect`, in registration order."""
     port = _free_port()
     srv = subprocess.Popen([sys.executable, str(STUB)],
-                           env={"DEFECT": defect, "PORT": str(port), "PATH": "/usr/bin:/bin"},
+                           env={"DEFECT": defect, "DIALECT": dialect, "PORT": str(port),
+                                "PATH": "/usr/bin:/bin"},
                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     try:
         deadline = time.time() + 10
@@ -119,3 +120,30 @@ def test_no_check_errors_on_any_defect():
     for defect in ["none", *CAUGHT_BY]:
         out = _run_series(defect)
         assert Outcome.ERROR not in out.values(), f"{defect}: {out}"
+
+
+# ── the toggle dialect ────────────────────────────────────────────────────────────────
+# The reference implementation does not speak §5's bodyless POST: the body carries the target
+# state, an empty body is a validation error, and revocation is {"enabled": false}. The series
+# must drive that dialect too — it skipped all seven against the reference until it did — and
+# driving it must not cost any detection.
+
+
+def test_a_conformant_toggle_dialect_server_passes_every_check():
+    out = _run_series("none", dialect="enabled")
+    assert all(o is Outcome.PASS for o in out.values()), out
+
+
+def test_the_toggle_dialects_revocation_is_still_a_real_probe():
+    """R-06's last attempt believes a 200 only when it speaks revocation's vocabulary, so a
+    toggle server whose revocation lies must still be caught through that path."""
+    out = _run_series("revoke_lies", dialect="enabled")
+    assert out["R-06"] is Outcome.FAIL, out
+    assert [i for i, o in out.items() if o is Outcome.FAIL] == ["R-06"], out
+
+
+def test_the_dialect_retry_does_not_hide_a_missing_feature():
+    """A server with no sharing at all still skips, never fails: the retry only fires on a
+    validation error, and 404/405/501 mean today what they meant before it existed."""
+    out = _run_series("none", dialect="plain")   # the plain stub already proves pass; this
+    assert Outcome.ERROR not in out.values()     # guards the retry against breaking it

--- a/protocol/conformance/uhp_conformance/checks.py
+++ b/protocol/conformance/uhp_conformance/checks.py
@@ -825,3 +825,298 @@ def f02(ctx):
         "accepts a base it cannot run fails at task time instead, after the client has committed.")
     if r.status == 200:  # defensive: clean up if the server accepted it after all
         ctx.client.delete(f"/v1/harnesses/{(r.json or {}).get('id')}")
+
+
+# ══════════════════════════════════════════════════════════════════════════════════════
+# Full — session sharing
+# ══════════════════════════════════════════════════════════════════════════════════════
+# Sessions §5 is the Full requirement this suite could not see, and it is the one where a
+# happy-path check would be worse than no check at all: almost every sentence in §5 is about
+# what the server REFUSES. A check that minted a link and read the conversation back would
+# pass against a server that also let that link continue the task, cancel the run, or upload
+# into the working directory — and an unauthenticated write path into someone's working
+# directory is about as bad as a defect in this protocol gets.
+#
+# §5 says a server MAY publish a shared view, so every check below skips — never fails — on a
+# server that does not implement sharing. What is not optional is the shape of it once it does.
+#
+# §5 names two endpoints and no others: it does not say where the view is served, and it does
+# not name a revocation path. So these checks discover both from what the server itself
+# returned, rather than assuming any one implementation's URLs. Where discovery is impossible
+# the check skips and names the missing sentence, because that is a gap in the specification
+# rather than a defect in the server being tested.
+
+# Keys whose non-empty presence in a shared view would breach §5's third bullet. `headers` and
+# `env` are here because that is where an MCP server's credentials live (Harnesses §4.1).
+_SECRET_KEYS = {"auth", "authorization", "api_key", "apikey", "token", "access_token",
+                "refresh_token", "secret", "password", "credentials", "env", "headers"}
+
+
+def _walk(node, path="$"):
+    """Every (json-path, key, value) pair in a document, so a finding can say where it is."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            here = f"{path}.{k}"
+            yield here, k, v
+            yield from _walk(v, here)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _walk(v, f"{path}[{i}]")
+
+
+def _view_path(ctx, url: str) -> str:
+    """The client-relative path for a URL the server handed back.
+
+    The share URL may be absolute or relative, and the base URL may carry a path prefix
+    (`https://host/api/harness`), so neither can simply be concatenated. A view on a different
+    origin is not something this suite can attest, and says so rather than guessing.
+    """
+    from urllib.parse import urlsplit
+    base, u = urlsplit(ctx.client.base_url), urlsplit(url)
+    if u.netloc and u.netloc != base.netloc:
+        raise Skip(f"the shared view is served on another origin ({u.netloc}), which this suite "
+                   "cannot reach or attest")
+    prefix = base.path.rstrip("/")
+    path = u.path if not prefix or not u.path.startswith(prefix) else u.path[len(prefix):]
+    return path + (f"?{u.query}" if u.query else "")
+
+
+def _shared_session_id(ctx) -> str:
+    sid = ctx.state.get("session_id")
+    if sid:
+        return sid
+    sid = ((_run_blocking(ctx).json or {}).get("metadata") or {}).get("session_id")
+    if not sid:
+        raise Skip("no session id from an earlier task, so there is nothing to share")
+    return sid
+
+
+def _share(ctx) -> dict:
+    """Mint the share once and cache it, or skip with the reason it could not be minted."""
+    if "share" in ctx.state:
+        got = ctx.state["share"]
+        if isinstance(got, str):        # a cached skip reason: do not re-POST on every check
+            raise Skip(got)
+        return got
+
+    def _skip(reason):
+        ctx.state["share"] = reason
+        raise Skip(reason)
+
+    caps = (ctx.state.get("discovery") or {}).get("capabilities") or {}
+    if caps.get("session_sharing") is False:
+        _skip("this server reports session_sharing false, and Sessions §5 is a MAY")
+    sid = _shared_session_id(ctx)
+    r = ctx.client.post(f"/v1/sessions/{sid}/share")
+    if r.status in (404, 405, 501):
+        _skip(f"POST /v1/sessions/{{id}}/share returned HTTP {r.status}: this server does not "
+              "publish shared views, which Sessions §5 permits")
+    if r.status != 200 or not isinstance(r.json, dict):
+        _skip(f"POST /v1/sessions/{{id}}/share returned HTTP {r.status}, which is neither a share "
+              f"nor a refusal this check can read: {r.body[:160]!r}")
+    d = r.json
+    url = next((d[k] for k in ("url", "share_url", "href", "link", "location")
+                if isinstance(d.get(k), str) and d[k]), "") or r.header("location")
+    if not url:
+        _skip("the share carries no URL, and Sessions §5 does not say where a shared view is "
+              f"served, so this check cannot locate it (keys: {sorted(d)[:8]}). The specification "
+              "should name the view's endpoint, or the share object should be schema'd with a "
+              "field that does.")
+    share = {"id": d.get("id") or "", "url": url, "path": _view_path(ctx, url), "session_id": sid,
+             "body": d}
+    ctx.state["share"] = share
+    return share
+
+
+@check("R-01", "A shared session is published, and the link alone opens it", "full",
+       f"{SPEC}/sessions.md#5-session-sharing")
+def r01(ctx):
+    sh = _share(ctx)
+    r = ctx.client.get(sh["path"], auth=False)
+    assert r.status == 200, (
+        f"the URL the server published for this share returned HTTP {r.status} when opened with no "
+        "credential. Sessions §5 is about publishing a view: one that only the principal who minted "
+        "it can open has not been published to anyone.")
+    ctx.state["share_readable"] = True
+    body = r.json
+    assert body is not None, f"the shared view is not JSON: {r.body[:120]!r}"
+    return f"readable unauthenticated at {sh['path']}"
+
+
+@check("R-02", "The share can be read back from the endpoint that minted it", "full",
+       f"{SPEC}/sessions.md#5-session-sharing")
+def r02(ctx):
+    sh = _share(ctx)
+    r = ctx.client.get(f"/v1/sessions/{sh['session_id']}/share")
+    assert r.status == 200, (
+        f"GET /v1/sessions/{{id}}/share returned HTTP {r.status} for a session that has a share. §5 "
+        "names this endpoint, and a client that has lost the link has nowhere else to ask.")
+    d = r.json or {}
+    got = next((d[k] for k in ("url", "share_url", "href", "link", "location")
+                if isinstance(d.get(k), str) and d[k]), "")
+    assert got, f"the share read back carries no URL (keys: {sorted(d)[:8]})"
+    assert _view_path(ctx, got) == sh["path"], (
+        f"GET reports a different view ({_view_path(ctx, got)}) from the one POST published "
+        f"({sh['path']}). A client cannot revoke, or even name, a link it is told two versions of.")
+    if sh["id"] and d.get("id"):
+        assert d["id"] == sh["id"], f"share id changed between POST and GET: {sh['id']} → {d['id']}"
+    return "GET agrees with POST"
+
+
+@check("R-03", "A share id is not a credential for the API", "full",
+       f"{SPEC}/sessions.md#5-session-sharing")
+def r03(ctx):
+    sh = _share(ctx)
+    ident = sh["id"] or sh["path"].rstrip("/").rsplit("/", 1)[-1]
+    if not ident:
+        raise Skip("the share exposes no id to present as a token")
+    # Only endpoints this server actually serves to the real credential can say anything about a
+    # wrong one: a 404 or a 405 is the router declining a path, not the guard declining a token.
+    guarded = [p for p in ("/v1/sessions", "/v1/responses", "/v1/harnesses")
+               if 200 <= ctx.client.get(p).status < 300]
+    if not guarded:
+        raise Skip("no authenticated GET endpoint answered the real credential, so nothing here "
+                   "can distinguish a refused token from an absent route")
+    accepted = [f"{p} → HTTP {r.status}" for p, r in
+                ((p, ctx.client.get(p, headers={"authorization": f"Bearer {ident}"}))
+                 for p in guarded)
+                if 200 <= r.status < 300]
+    assert not accepted, (
+        "the share id is accepted as a bearer token: " + "; ".join(accepted) + ". §5 forbids a "
+        "shared view exposing another principal's data, and a link that authenticates the API "
+        "exposes all of it — every session, every response, every configured harness.")
+    return f"refused on {len(guarded)} endpoint(s)"
+
+
+@check("R-04", "The shared view is read-only", "full", f"{SPEC}/sessions.md#5-session-sharing")
+def r04(ctx):
+    sh = _share(ctx)
+    if not ctx.state.get("share_readable"):
+        raise Skip("the shared view did not resolve (see R-01), so what it refuses cannot be read")
+    view = sh["path"].split("?")[0].rstrip("/")
+    probes = [("POST", view), ("PUT", view), ("PATCH", view), ("DELETE", view),
+              # The three §5 names outright, at the paths this protocol uses for them elsewhere.
+              ("POST", f"{view}/cancel"), ("POST", f"{view}/responses"), ("POST", f"{view}/files")]
+    accepted = []
+    for method, path in probes:
+        body = {} if method != "DELETE" else None
+        r = ctx.client.request(method, path, body=body, auth=False)
+        if 200 <= r.status < 300:
+            accepted.append(f"{method} {path} → HTTP {r.status}")
+    assert not accepted, (
+        "the shared view accepted a write from a caller holding only the link: "
+        + "; ".join(accepted) + ". §5: the view MUST NOT permit continuing, cancelling, or "
+        "uploading. This is an unauthenticated write into someone else's session.")
+    return f"{len(probes)} write probes refused"
+
+
+@check("R-05", "The shared view exposes no credentials", "full",
+       f"{SPEC}/sessions.md#5-session-sharing")
+def r05(ctx):
+    sh = _share(ctx)
+    if not ctx.state.get("share_readable"):
+        raise Skip("the shared view did not resolve (see R-01), so its contents cannot be read")
+    r = ctx.client.get(sh["path"], auth=False)
+    raw = r.body.decode("utf-8", "replace")
+    if ctx.client.api_key:
+        assert ctx.client.api_key not in raw, (
+            "the shared view contains this client's API key verbatim. §5: a shared view MUST NOT "
+            "expose provider credentials or tokens.")
+    leaks = [p for p, k, v in _walk(r.json)
+             if k.lower() in _SECRET_KEYS and v not in (None, "", {}, [], False)]
+    assert not leaks, (
+        f"the shared view carries credential-shaped fields with values: {leaks[:5]}. §5 forbids "
+        "exposing provider credentials or tokens; Harnesses §4.1 puts an MCP server's `auth` and "
+        "`headers` among them, and the holder of a link is a client that presented nothing.")
+    return "no credential-shaped fields"
+
+
+@check("R-06", "Revocation kills every link minted for the session", "full",
+       f"{SPEC}/sessions.md#5-session-sharing")
+def r06(ctx):
+    sh = _share(ctx)
+    if not ctx.state.get("share_readable"):
+        raise Skip("the shared view never resolved (see R-01), so 'stops resolving' cannot be "
+                   "distinguished from 'never resolved'")
+    sid = sh["session_id"]
+
+    # Share the session a second time before revoking. §5 does not say whether a second POST
+    # returns the first link or mints another, and this check does not require either — but
+    # whichever it did, revocation has to reach what it produced. A server that hands out a
+    # second link and then revokes only the newest has told the operator the session is private
+    # while a live link to it is still in someone's hands.
+    live = [sh["path"]]
+    again = ctx.client.post(f"/v1/sessions/{sid}/share")
+    if again.status == 200 and isinstance(again.json, dict):
+        url = next((again.json[k] for k in ("url", "share_url", "href", "link", "location")
+                    if isinstance(again.json.get(k), str) and again.json[k]), "")
+        if url and _view_path(ctx, url) not in live:
+            live.append(_view_path(ctx, url))
+
+    # §5 requires revocation and names no path, so the endpoint has to be searched for.
+    attempts = [("DELETE", f"/v1/sessions/{sid}/share"),
+                ("POST", f"/v1/sessions/{sid}/share/revoke"),
+                ("DELETE", f"/v1/shares/{sh['id']}" if sh["id"] else "")]
+    done = ""
+    for method, path in attempts:
+        if not path:
+            continue
+        r = ctx.client.request(method, path)
+        if 200 <= r.status < 300:
+            done = f"{method} {path}"
+            break
+    if not done:
+        raise Skip(
+            "Sessions §5 requires that a share be revocable and names no endpoint for it, so this "
+            "check cannot locate one. The specification should name a path: a MUST with no "
+            "endpoint is a MUST that every implementation satisfies differently, and no portable "
+            "check can confirm it.")
+
+    ctx.state["share"] = "the share minted for this run was revoked by R-06"
+    ctx.state["share_readable"] = False
+    alive = [(p, ctx.client.get(p, auth=False).status) for p in live]
+    bad = [f"{p} → HTTP {s}" for p, s in alive if s not in (404, 410)]
+    assert not bad, (
+        f"a published link still resolves after {done} reported success: " + "; ".join(bad) +
+        ". A revocation that answers 200 and leaves a link live is worse than none, because the "
+        "operator has been told the session is no longer published.")
+    return (f"revoked via {done}; {len(live)} link(s) minted, all now "
+            f"{'/'.join(str(s) for _, s in alive)}")
+
+
+@check("R-07", "Deleting a session takes its shared view with it", "full",
+       f"{SPEC}/sessions.md#6-deleting")
+def r07(ctx):
+    # A session this check may destroy: deleting the one the rest of the suite shares would make
+    # every later check fail for the wrong reason. That costs one extra agent run on a full pass.
+    h = _harness(ctx)
+    body = {"input": PROMPT, "metadata": {"harness_id": h["id"]}, "stream": False}
+    if ctx.model:
+        body["model"] = ctx.model
+    started = ctx.client.post("/v1/responses", body=body)
+    sid = ((started.json or {}).get("metadata") or {}).get("session_id")
+    if started.status != 200 or not sid:
+        raise Skip(f"could not start a disposable session (HTTP {started.status})")
+
+    minted = ctx.client.post(f"/v1/sessions/{sid}/share")
+    if minted.status != 200 or not isinstance(minted.json, dict):
+        raise Skip(f"could not share the disposable session (HTTP {minted.status})")
+    url = next((minted.json[k] for k in ("url", "share_url", "href", "link", "location")
+                if isinstance(minted.json.get(k), str) and minted.json[k]), "")
+    if not url:
+        raise Skip("the share carries no URL, so the view cannot be located (see R-01)")
+    path = _view_path(ctx, url)
+    if ctx.client.get(path, auth=False).status != 200:
+        raise Skip("the disposable share's view did not resolve, so its disappearance proves nothing")
+
+    gone = ctx.client.delete(f"/v1/traces/{sid}")
+    if gone.status in (404, 405, 501):
+        raise Skip(f"DELETE /v1/traces/{{id}} returned HTTP {gone.status}, so a session cannot be "
+                   "deleted here and this check has nothing to observe")
+    assert 200 <= gone.status < 300, f"deleting the session returned HTTP {gone.status}"
+    after = ctx.client.get(path, auth=False)
+    assert after.status in (404, 410), (
+        f"the shared link still returns HTTP {after.status} for a session that was deleted. §6 "
+        "requires the session be unreadable after deletion, and a published link is the one way "
+        "in that its owner is least likely to remember.")
+    return f"session deleted, then HTTP {after.status}"

--- a/protocol/conformance/uhp_conformance/checks.py
+++ b/protocol/conformance/uhp_conformance/checks.py
@@ -891,6 +891,21 @@ def _shared_session_id(ctx) -> str:
     return sid
 
 
+def _mint_share(ctx, sid: str):
+    """POST the share, speaking both dialects §5's silence allows.
+
+    §5 documents POST with no body, but a server that models sharing as a toggle carries the
+    target state in the body and refuses an empty one with a validation error (the reference
+    implementation among them, verified live). A 4xx naming a missing body field is a dialect
+    answer, not a refusal to share — while 404/405/501 stay exactly what they were: not
+    implemented. ONE function, because R-07 mints its own disposable share and a second copy of
+    this decision already drifted once (R-07 skipped on servers _share could drive)."""
+    r = ctx.client.post(f"/v1/sessions/{sid}/share")
+    if r.status in (400, 422):
+        r = ctx.client.post(f"/v1/sessions/{sid}/share", body={"enabled": True})
+    return r
+
+
 def _share(ctx) -> dict:
     """Mint the share once and cache it, or skip with the reason it could not be minted."""
     if "share" in ctx.state:
@@ -907,7 +922,7 @@ def _share(ctx) -> dict:
     if caps.get("session_sharing") is False:
         _skip("this server reports session_sharing false, and Sessions §5 is a MAY")
     sid = _shared_session_id(ctx)
-    r = ctx.client.post(f"/v1/sessions/{sid}/share")
+    r = _mint_share(ctx, sid)
     if r.status in (404, 405, 501):
         _skip(f"POST /v1/sessions/{{id}}/share returned HTTP {r.status}: this server does not "
               "publish shared views, which Sessions §5 permits")
@@ -1054,17 +1069,27 @@ def r06(ctx):
             live.append(_view_path(ctx, url))
 
     # §5 requires revocation and names no path, so the endpoint has to be searched for.
-    attempts = [("DELETE", f"/v1/sessions/{sid}/share"),
-                ("POST", f"/v1/sessions/{sid}/share/revoke"),
-                ("DELETE", f"/v1/shares/{sh['id']}" if sh["id"] else "")]
+    attempts = [("DELETE", f"/v1/sessions/{sid}/share", None),
+                ("POST", f"/v1/sessions/{sid}/share/revoke", None),
+                ("DELETE", f"/v1/shares/{sh['id']}" if sh["id"] else "", None),
+                # The toggle dialect (the reference implementation's native form). Tried LAST,
+                # and believed only when the answer speaks revocation's own vocabulary: a
+                # bodyless-dialect server would 200 this by MINTING — it ignores the body — and
+                # a mint mistaken for a revocation would fail this check with a false message.
+                ("POST", f"/v1/sessions/{sid}/share", {"enabled": False})]
     done = ""
-    for method, path in attempts:
+    for method, path, payload in attempts:
         if not path:
             continue
-        r = ctx.client.request(method, path)
-        if 200 <= r.status < 300:
-            done = f"{method} {path}"
-            break
+        r = ctx.client.request(method, path, body=payload)
+        if not 200 <= r.status < 300:
+            continue
+        if payload is not None:
+            d = r.json if isinstance(r.json, dict) else {}
+            if not (d.get("enabled") is False or d.get("deleted") is True):
+                continue
+        done = f"{method} {path}"
+        break
     if not done:
         raise Skip(
             "Sessions §5 requires that a share be revocable and names no endpoint for it, so this "
@@ -1098,7 +1123,7 @@ def r07(ctx):
     if started.status != 200 or not sid:
         raise Skip(f"could not start a disposable session (HTTP {started.status})")
 
-    minted = ctx.client.post(f"/v1/sessions/{sid}/share")
+    minted = _mint_share(ctx, sid)
     if minted.status != 200 or not isinstance(minted.json, dict):
         raise Skip(f"could not share the disposable session (HTTP {minted.status})")
     url = next((minted.json[k] for k in ("url", "share_url", "href", "link", "location")

--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -54,6 +54,11 @@ function isPublic(path: string): boolean {
     // only for a token whose owner has sharing switched on, and with nothing but that session.
     || path.startsWith('/share/')
     || path.startsWith('/api/share/')
+    // The same share surface through the API base: a share object's `url` is relative to the
+    // base the client already uses, so a conformance client on /api/harness resolves it to
+    // /api/harness/share/{token} — the gateway's own public share routes, relayed. The token is
+    // the credential there exactly as it is on /share/ and /api/share/ above.
+    || path.startsWith('/api/harness/share/')
     || path.startsWith('/_next/')
     // An /api path is never a static asset, whatever it ends with. Neither is /data — those are
     // files a TASK produced, and agents write .png, .svg, .css and .js routinely. Matching those


### PR DESCRIPTION
Fixes the coverage half of #44. The four specification questions in that issue stay open there —
none of them are needed to land this.

## What's wrong today

At `6fdb96e`, `/share` appears in none of the 52 checks, and neither does `session_sharing`.
Sessions §5 is a Full chapter, so a passing `full` run tells you nothing about whether sharing
works on that server.

It's a worse gap than the suite's other blind spots because §5 is mostly a list of refusals. The
check you'd write first — mint a link, read the conversation back — passes just as happily
against a server that also lets that link continue the task, cancel the run, or upload files
into the working directory. The happy path is the one bit of §5 you can get right by accident.

## What this adds

`R-01` through `R-07` at class Full. Each names the sentence it enforces.

```
R-01  A shared session is published, and the link alone opens it        §5
R-02  The share can be read back from the endpoint that minted it       §5
R-03  A share id is not a credential for the API                        §5
R-04  The shared view is read-only (7 write probes)                     §5
R-05  The shared view exposes no credentials                            §5
R-06  Revocation kills every link minted for the session                §5
R-07  Deleting a session takes its shared view with it                  §6
```

§5 makes sharing optional, so every one of these **skips rather than fails** on a server that
doesn't implement it. And since §5 names no endpoint for the view or for revocation, the checks
find both from what the server returned and skip with the missing sentence as the reason. A hole
in the spec shouldn't read as a failure by the server being tested.

Two things left out on purpose, in case they look like oversights:

- **R-02 doesn't require `POST` to be idempotent.** §5 doesn't say whether a second `POST`
  returns the existing link or mints a new one, so either is fine. What R-06 does insist on is
  that revocation reaches whatever got minted — revoking only the newest tells an operator the
  session is private while somebody still holds a working link. That comes out of "MUST allow
  revocation", not out of my preferences.
- **R-01 doesn't require the view to be anonymous in general.** It follows the URL the server
  published, unmodified, adding no credential. A URL carrying its own token passes fine. A view
  only its creator can open doesn't, because that hasn't been published to anyone.

## The tests are the point

A check that only ever passes can't tell a server that refuses from one that doesn't — which is
what happened to D-05. So `tests/share_defect_stub.py` is a deliberately wrong UHP server with
one switchable defect per rule, and `tests/test_session_sharing_checks.py` runs the series
against each defect in turn:

| Defect | R-01 | R-02 | R-03 | R-04 | R-05 | R-06 | R-07 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| *(none)* | pass | pass | pass | pass | pass | pass | pass |
| view demands the owner's credential | **FAIL** | pass | pass | skip | skip | skip | skip |
| `GET /share` reports a different link | pass | **FAIL** | pass | pass | pass | pass | pass |
| share id authenticates the real API | pass | pass | **FAIL** | pass | pass | pass | pass |
| shared view accepts writes | pass | pass | pass | **FAIL** | pass | pass | pass |
| view exposes MCP `auth` / `headers` | pass | pass | pass | pass | **FAIL** | pass | pass |
| revoke answers 200 and revokes nothing | pass | pass | pass | pass | pass | **FAIL** | pass |
| second `POST` mints a link revoke misses | pass | pass | pass | pass | pass | **FAIL** | pass |
| link outlives its deleted session | pass | pass | pass | pass | pass | pass | **FAIL** |

The test asserts all four properties of that table: a clean server passes everything, each defect
is caught by its own check, **no other check fails on it** (one bug, one red mark), and nothing
ever comes back as ERROR. The four skips in row two are asserted too — if the view never
resolved, "stops resolving" and "never resolved" are the same observation, so those checks stay
quiet instead of piling four red marks onto one bug.

The stub answers every task itself, so it needs no credentials, no network and no agent tokens.

```
$ python -m pytest protocol/conformance/tests -q
26 passed in 2.35s
```

That's the whole existing suite plus this, so the `conformance` job in `tests.yml` picks it up
with no workflow change and about two seconds added.

## Also verified against a real implementation

7/7 against a third-party Go UHP server that implements §5 (`claude-code` / `claude-sonnet-5`),
so the series isn't shaped around the stub.

## Numbers that move

Full goes 7 → 14 checks and the suite 52 → 59, so published conformance scores move with it. I
updated the counts in `protocol/conformance/README.md` and added an `R-01…R-07` entry to the
"worth calling out" list.

I **did not** touch the recorded `52/52` run in the Outcomes section. I haven't re-measured the
reference implementation, and rewriting a recorded result I didn't reproduce seemed worse than
leaving it and marking it as predating the series. Happy to drop that note if you'd rather
re-measure and restate it.

## Compatibility and scope

- No specification change and no schema change required.
- No `CHANGELOG.md` entry: `protocol/CHANGELOG.md` tracks protocol versions, and the protocol
  is unchanged here. Say the word if you'd like one anyway.
- Nothing existing was modified except the README counts.
- The four gaps in #44 (revocation endpoint, view endpoint, share object, `turns` items) would
  let several of these stop probing and start asserting. Glad to write that follow-up if you
  pick a direction.

Licensed under Apache-2.0, same as the repository.
