### PR TITLE
conformance: the one sentence of §5 the retry was hiding

### DIFF
--- a/protocol/CHANGELOG.md
+++ b/protocol/CHANGELOG.md
@@ -26,6 +26,16 @@ All notable changes to the Unified Harness Protocol.
   skips) when it does not work; `X-04` validates every turn item. New defect stub mode:
   a server whose revocation exists only as a toggle now fails `R-06`.
 
+- **`R-08`: a bodyless `POST` publishes.** The sentence was written into §5 above and left
+  unenforced, named as a known gap rather than hidden. The rest of the R-series mints through a
+  helper that retries a 400/422 with `{"enabled": true}` — the retry is what lets the series
+  measure a toggle-dialect server at all, and it is also what let this sentence go untested: such
+  a server passes `R-01`…`R-07` on a request §5 does not require anyone to accept, while refusing
+  the one it does. `R-08` is the one check that does not retry. New defect stub mode,
+  `bodyless_rejected`, is what the reference implementation was before this series existed; the
+  matrix proves `R-08` is the only check that reddens on it. No specification or schema change:
+  this enforces a sentence that is already written.
+
 
 - **`tools` and `include` are reserved and ignored** ([Tasks §1.4](versions/2026-08-11/tasks.md#14-reserved-fields-tools-and-include)).
   Both arrived with the OpenAI Responses wire shape this version stays compatible with, and neither

--- a/protocol/conformance/README.md
+++ b/protocol/conformance/README.md
@@ -37,13 +37,13 @@ anything that only inspects a schema.
 
 ## What it checks
 
-62 checks across three classes.
+63 checks across three classes.
 
 | Class | Checks | Covers |
 |---|---|---|
 | **Core** | 40 | Discovery, version negotiation, authentication, the error envelope, harnesses, models, task execution (streaming and not), the event stream, sessions, cancellation, reserved request fields |
 | **Extended** | +8 | Session listing and inspection, file input, artifacts, download headers, path-traversal probes |
-| **Full** | +14 | Harness create / update / delete, refusal of an unsupported base, skill-folder round trip, MCP and disabled-tool persistence, session sharing |
+| **Full** | +15 | Harness create / update / delete, refusal of an unsupported base, skill-folder round trip, MCP and disabled-tool persistence, session sharing |
 
 Every check names the section of the specification it enforces, so a failure points at the sentence
 it violates rather than at a test name.
@@ -68,15 +68,22 @@ A few of them are worth calling out, because they catch things a schema check ne
   ignored. Both halves matter: before these, the suite sent neither field, so a server that
   rejected them outright and a server that silently acted on them scored the same as a correct
   one. T-10 covers the third mistake, a server that reports fields the request never sent.
-- **R-01…R-07** — session sharing, which is mostly a set of refusals. Sessions §5 requires that a
+- **R-01…R-08** — session sharing, which is mostly a set of refusals. Sessions §5 requires that a
   shared view be read-only, revocable, and free of credentials, and a check that merely opens a
   link and reads the conversation passes against a server that also lets that link continue the
   task, cancel the run, or upload into the working directory. §5 makes sharing optional, so these
-  skip rather than fail on a server that does not implement it; and because §5 names no endpoint
-  for the view or for revocation, they discover both from what the server returned and skip with
-  the missing sentence as the reason. `tests/test_session_sharing_checks.py` runs the series
-  against a deliberately wrong server, one defect at a time, so each of them is known to fail on
-  the mistake it describes.
+  skip rather than fail on a server that does not implement it. Since §5 named the share object's
+  `url` and `DELETE` on the mint endpoint, `R-01`, `R-02` and `R-06` assert both rather than
+  discovering them — they used to skip with the missing sentence as the reason.
+  `tests/test_session_sharing_checks.py` runs the series against a deliberately wrong server, one
+  defect at a time, so each of them is known to fail on the mistake it describes.
+- **R-08** — a bodyless `POST` publishes. The series mints through a helper that retries a 400/422
+  with `{"enabled": true}`, because a server speaking only that dialect would otherwise skip all
+  seven of the checks above — so the retry is what makes the series portable, and it is also what
+  hides this sentence: a toggle-only server passes `R-01`…`R-07` on the strength of a request §5
+  does not require anyone to accept, while refusing the one it does. `R-08` is the one check that
+  does not retry. Its stub defect, `bodyless_rejected`, is what the reference implementation was
+  before this series existed.
 - **F-03/F-04** — a skill is a folder, and it survives an unrelated edit. A server that stores only
   `SKILL.md`, or that empties a bundle when the harness is renamed, passes every other check: the
   config still looks right, and the loss only shows up later as an agent behaving oddly.
@@ -130,6 +137,14 @@ self-hosted instance, and both measured a real defect before passing:
   idempotency hash and nothing reported it ignored — the silent drop §1.1 now forbids.
 
 A suite that had shipped happy-path checks would have called that server conformant both times.
+
+`R-08` was added afterwards, from a gap the PR that closed those two named in its own body rather
+than left to be found: *"a body is OPTIONAL; no body means publish" has no dedicated check yet.*
+It passes against the reference and against an independent Go implementation (63/63 `full`, zero
+skipped, on the latter). Neither server can currently fail it — which is the argument for the
+check, not against it: two implementations agreeing by coincidence is what a specification
+sentence is supposed to stop being true by, and nothing in either tree would have noticed one of
+them stopping.
 
 The suite is developed against that implementation, which is exactly why the specification says
 conformance is defined by the suite and not by the implementation: anything the reference does that

--- a/protocol/conformance/tests/share_defect_stub.py
+++ b/protocol/conformance/tests/share_defect_stub.py
@@ -41,6 +41,10 @@ DEFECTS = {
     "share_outlives_session",  # the link survives the deletion of its session
     "no_delete_revocation",  # revocation exists only as the {"enabled": false} toggle; the
                              # endpoint §5 NAMES (DELETE on /share) answers 405
+    "bodyless_rejected",     # a bodyless POST is a validation error; only {"enabled": true}
+                             # publishes. This is what the reference implementation was before
+                             # #45, and every other R- check still passes on it, because the
+                             # mint helper retries. R-08 is the one that must not.
 }
 assert DEFECT in DEFECTS, f"unknown defect {DEFECT!r}; one of {sorted(DEFECTS)}"
 
@@ -156,6 +160,20 @@ class H(BaseHTTPRequestHandler):
         existing = BY_SESSION.get(sid) or []
 
         if method == "POST" and not rest:
+            if DEFECT == "bodyless_rejected":
+                # §5 makes the body OPTIONAL. This server makes it mandatory, which is a
+                # narrower contract wearing a conformant one's clothes: R-01…R-07 are all
+                # reachable through the mint helper's retry, so only a check that refuses to
+                # retry can see it.
+                try:
+                    body = json.loads(self.body or b"null")
+                except Exception:
+                    body = None
+                if not isinstance(body, dict) or "enabled" not in body:
+                    return self.send(422, {"error": {"code": "invalid_request",
+                                                     "message": "field required: enabled"}})
+                if body.get("enabled") is False:
+                    return self.revoke(sid, existing)
             if DIALECT == "enabled":
                 # §5: a body is OPTIONAL and no body means publish. This dialect ALSO accepts the
                 # toggle body, which §5 permits ("a server MAY accept {"enabled": bool}").

--- a/protocol/conformance/tests/test_session_sharing_checks.py
+++ b/protocol/conformance/tests/test_session_sharing_checks.py
@@ -39,6 +39,7 @@ CAUGHT_BY = {
     "multi_mint": "R-06",
     "no_delete_revocation": "R-06",
     "share_outlives_session": "R-07",
+    "bodyless_rejected": "R-08",
 }
 
 
@@ -77,7 +78,7 @@ def _run_series(defect: str, dialect: str = "plain") -> dict[str, Outcome]:
 
 def test_the_series_is_registered_at_full():
     ids = [c.id for c in REGISTRY if c.id.startswith("R-")]
-    assert ids == [f"R-0{i}" for i in range(1, 8)]
+    assert ids == [f"R-0{i}" for i in range(1, 9)]
     assert {c.cls for c in REGISTRY if c.id.startswith("R-")} == {"full"}
 
 
@@ -148,3 +149,19 @@ def test_the_dialect_retry_does_not_hide_a_missing_feature():
     validation error, and 404/405/501 mean today what they meant before it existed."""
     out = _run_series("none", dialect="plain")   # the plain stub already proves pass; this
     assert Outcome.ERROR not in out.values()     # guards the retry against breaking it
+
+
+def test_the_toggle_dialect_is_not_a_licence_to_refuse_a_bodyless_post():
+    """The retry exists so a toggle server can be MEASURED, not so it can be excused.
+
+    `enabled` is the dialect of a server that also accepts §5's bodyless POST — the reference
+    implementation since #53 — so it must pass R-08 like everything else. `bodyless_rejected` is
+    the server that only accepts the toggle, and it must fail R-08 and nothing else: every other
+    check reaches it through the retry, which is exactly the hiding this check was written to
+    undo.
+    """
+    assert _run_series("none", dialect="enabled")["R-08"] is Outcome.PASS
+
+    out = _run_series("bodyless_rejected")
+    assert out["R-08"] is Outcome.FAIL, out
+    assert [i for i, o in out.items() if o is Outcome.FAIL] == ["R-08"], out

--- a/protocol/conformance/uhp_conformance/checks.py
+++ b/protocol/conformance/uhp_conformance/checks.py
@@ -1225,3 +1225,56 @@ def r07(ctx):
         "requires the session be unreadable after deletion, and a published link is the one way "
         "in that its owner is least likely to remember.")
     return f"session deleted, then HTTP {after.status}"
+
+
+@check("R-08", "A bodyless POST publishes, as §5 says it does", "full",
+       f"{SPEC}/sessions.md#5-session-sharing")
+def r08(ctx):
+    """§5: "a body is OPTIONAL; no body means publish."
+
+    Named in harnessrouter#53 as the one sentence of the chapter nothing enforced. The R-series
+    mints through a helper that retries a 400/422 with {"enabled": true}, because a server
+    speaking only the toggle dialect would otherwise skip all seven checks — so the retry is what
+    makes the series portable, and it is also what hides this sentence. A toggle-only server
+    passes R-01 through R-07 on the strength of a request §5 does not require anyone to accept,
+    while refusing the one it does.
+
+    That is worth a check rather than a note because the two servers this suite is measured
+    against both happen to publish on a bodyless POST today, so nothing in either tree would
+    notice if one stopped. A sentence enforced by coincidence is enforced until the coincidence
+    ends.
+
+    Deliberately NOT using _mint_share: the retry is the thing under test. And deliberately not
+    gated on _share either — that helper caches "revoked by R-06" once R-06 has run, so gating on
+    it would make this check skip on every conformant server, which is the failure mode it exists
+    to catch. The two skip conditions are restated here instead, from discovery and from the
+    status code, so the answer does not depend on what ran before."""
+    caps = (ctx.state.get("discovery") or {}).get("capabilities") or {}
+    if caps.get("session_sharing") is False:
+        raise Skip("this server reports session_sharing false, and Sessions §5 is a MAY")
+    sid = _shared_session_id(ctx)
+
+    r = ctx.client.post(f"/v1/sessions/{sid}/share")
+    if r.status in (404, 405, 501):
+        # Not-implemented answers, exactly as _share reads them. A server refusing only the
+        # *body* answers 400/422 — a method-level refusal cannot be the toggle dialect — so
+        # this is not an escape hatch for the mistake below.
+        raise Skip(f"POST /v1/sessions/{{id}}/share returned HTTP {r.status}: this server does "
+                   "not publish shared views, which Sessions §5 permits")
+    assert 200 <= r.status < 300, (
+        f"POST /v1/sessions/{{id}}/share with no body returned HTTP {r.status}: {r.body[:160]!r}. "
+        "§5 makes the body OPTIONAL and says no body means publish. A server that accepts only "
+        "{\"enabled\": true} has made a field mandatory that the specification made optional, so "
+        "a conformant client written against §5 cannot publish here at all.")
+    d = r.json if isinstance(r.json, dict) else {}
+    assert d.get("id") and d.get("url"), (
+        f"the bodyless POST answered HTTP {r.status} but not a share object (keys: "
+        f"{sorted(d)[:8]}). Accepting the request and returning something else is the same "
+        "failure one step later: the caller still cannot open what it just published.")
+
+    # Best-effort tidy-up, unasserted. This check publishes a link on a real server and R-06 has
+    # already proved DELETE revokes, so leaving one live would be a surprise for whoever ran the
+    # suite — but a failure here is R-06's finding to report, not this one's, and asserting it
+    # would diagnose one bug twice.
+    ctx.client.delete(f"/v1/sessions/{sid}/share")
+    return "published with no body"


### PR DESCRIPTION
Takes the follow-up #53 named in its own body rather than left to be found:

> **Known-unenforced sentence, named rather than hidden.** "a body is OPTIONAL; no body means
> publish" has no dedicated check yet: the suite's first mint is bodyless, but a server that 422s
> it and accepts the toggle is still driven via the retry rather than failed. Enforcing that
> sentence is a small follow-up; it is written here so it reads as a decision, not an oversight.

I said in the #53 thread I'd wait for the word before opening this. On reflection #45's precedent
was to bring something runnable to argue with instead of a description, so here it is — close it
unread if you'd rather draft it yourself.

## Why the sentence went untested, which is the interesting part

`_mint_share` retries a 400/422 with `{"enabled": true}`. That retry is load-bearing: without it
the whole R-series skipped against the reference, which is what your #45 review found. It is also
exactly what hides this sentence. A server that speaks *only* the toggle dialect passes
`R-01`…`R-07` on the strength of a request §5 does not require anyone to accept, while refusing
the one it does.

So the retry makes the series portable and makes one MUST unmeasurable, and both are true at once.
`R-08` is the one check that does not retry.

## What it asserts, and the two things it deliberately does not do

```
R-08  A bodyless POST publishes, as §5 says it does
```

**It is not gated on `_share`.** That was my first version and it was wrong in a way worth
recording: `_share` caches `"the share minted for this run was revoked by R-06"` once R-06 has
run, so gating on it made R-08 skip on every *conformant* server — the precise failure the check
exists to catch, reproduced inside the check itself. The two skip conditions are restated from
discovery and from the status code instead, so the answer does not depend on what ran before it.

**Reading 404/405/501 as not-implemented is not an escape hatch for the defect.** A server
refusing the *body* answers 400/422; a method-level refusal cannot be the toggle dialect. The
narrow reading is deliberate — a check that fails on a missing feature would be the same mistake
as `R-01`…`R-07` failing on a server that does not share at all.

It also revokes what it published, unasserted. R-06 has already proved `DELETE` works, so a
failure there is R-06's finding to report; asserting it here would diagnose one bug twice.

## The stub defect, and the matrix

`bodyless_rejected`: the body is mandatory, only `{"enabled": true}` publishes. That is what the
reference implementation was before #45 — so this is a defect with a real provenance rather than
an invented one.

| Defect | R-01 | R-02 | R-03 | R-04 | R-05 | R-06 | R-07 | R-08 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| *(none)* | pass | pass | pass | pass | pass | pass | pass | pass |
| `bodyless_rejected` | pass | pass | pass | pass | pass | pass | pass | **FAIL** |

Every other check reaches that server through the retry and passes, which is the whole argument
for the check in one row. The existing matrix tests pick it up from `CAUGHT_BY` — one defect one
red mark, no ERRORs, clean server passes everything — and one case is added on top: the conformant
`enabled` dialect must **pass** `R-08`, because the retry exists so a toggle server can be
*measured*, not so it can be *excused*.

```
$ python -m pytest protocol/conformance/tests -q
42 passed in 4.01s
```

39 before, so the three new cases run alongside everything else with no workflow change.

## Measured before shipped

63/63 `full`, zero skipped, against an independent Go UHP server (`claude-code`), with `R-08`
passing on a bodyless publish.

Worth being straight about the limit of that: **neither the reference nor my server can currently
fail R-08.** Both publish on a bodyless POST today. That is the argument for the check rather than
against it — two implementations agreeing by coincidence is the thing a specification sentence is
supposed to stop being true by, and nothing in either tree would have noticed one of them
stopping. It is the same shape as #44 one size down.

## Also in here

The conformance README's R-series bullet still said the checks "discover" the view and revocation
endpoints and "skip with the missing sentence as the reason". #53 stopped that being true when it
named both; the bullet is corrected to say they assert.

## Noticed in passing, not fixed here

`python protocol/schema/build.py --check` is red on `main` at `1176d9a5`, before this branch:

```
uhp-2026-08-11.schema.json is out of date — run: python protocol/schema/build.py
```

It is **descriptions only** — `SessionShare` and `TurnItem` carry text in the committed JSON that
differs in wording and wrapping from the OpenAPI source, and `$defs` ordering differs. Nothing
structural: `type`, `required` and `properties` are identical, so no validator behaves
differently and nothing here is affected. It looks like those two definitions were hand-written
into the JSON in #53 rather than regenerated.

Flagging it because the check-run list on #53 has `gateway`, `runner`, `conformance`, `console`
and `site` but no schema job, so nothing in CI would have said so — and because a downstream
implementation that vendors the JSON (mine does, to validate its published Go types against it)
now has a copy that its own generator would not reproduce. Happy to open it as an issue, or to
send the one-line regeneration as its own PR; it did not belong in this one.

Licensed under Apache-2.0, same as the repository.