### PR TITLE
feat(ui): files dropped on the conversation attach through the composer

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -50,7 +50,7 @@
         "react-markdown": "^9.1.0",
         "react-syntax-highlighter": "^16.1.1",
         "rehype-sanitize": "^6.0.0",
-        "reifyui": "git+https://github.com/epsilla-enterprise/ReifyUI.git#3ceb3148517567f3eb249764c5976bf43eb1df89",
+        "reifyui": "github:epsilla-enterprise/ReifyUI#37f3f56",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^3.4.1",
@@ -12670,8 +12670,7 @@
     },
     "node_modules/reifyui": {
       "version": "0.12.0",
-      "resolved": "git+ssh://git@github.com/epsilla-enterprise/ReifyUI.git#3ceb3148517567f3eb249764c5976bf43eb1df89",
-      "integrity": "sha512-NHOl9wExEzRIQSB9QleKx17URLkDe7gACNA2kM7q0ef7UyUibTCil2ScQsGiqmFiPGOT+RNq+oNzRgJTi6abBA==",
+      "resolved": "git+ssh://git@github.com/epsilla-enterprise/ReifyUI.git#37f3f5615e8a0b1e729801ded2ba8b72ae58954e",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,7 @@
     "react-markdown": "^9.1.0",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-sanitize": "^6.0.0",
-    "reifyui": "git+https://github.com/epsilla-enterprise/ReifyUI.git#3ceb3148517567f3eb249764c5976bf43eb1df89",
+    "reifyui": "github:epsilla-enterprise/ReifyUI#37f3f56",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.1",

--- a/ui/src/app/hr.css
+++ b/ui/src/app/hr.css
@@ -329,14 +329,10 @@ a { color: inherit; text-decoration: none; }
 /* ════════ Cowork-faithful chat polish ════════ */
 .wbx-conv { position: relative; }
 
-/* Drag-and-drop attach overlay: shown while files hover the conversation pane. */
-.wbx-droparea { position: absolute; inset: 0; z-index: 30; display: flex; align-items: center;
   justify-content: center; background: rgba(110, 85, 255, .06); pointer-events: none;
   border: 2px dashed var(--brand); border-radius: 12px; }
-.wbx-droparea-inner { display: flex; align-items: center; gap: 10px; padding: 14px 22px;
   border-radius: 12px; background: #fff; border: 1px solid var(--line);
   box-shadow: 0 8px 28px rgba(15, 23, 42, .14); font-size: 14px; font-weight: 700; color: var(--ink); }
-.wbx-droparea-inner iconify-icon { font-size: 20px; color: var(--brand); }
 /* align the two header chevrons: config head + recents top share a height, centered */
 .wbx-pane-head { height: 52px; padding: 0 12px 0 16px; }
 .wbx-recents-top { height: 52px; padding: 0 12px; gap: 10px; align-items: center; }

--- a/ui/src/components/TaskChat.tsx
+++ b/ui/src/components/TaskChat.tsx
@@ -485,48 +485,12 @@ function Conversation({ harnessId, sessionId, target, models, onModel, onRan, on
     }
     setFiles((p) => [...p, ...out]);
   }
-  // Drag-and-drop attach: dropping files anywhere on the conversation adds them to the composer.
-  // dragCount tracks nested enter/leave pairs (children fire their own events) so the highlight
-  // doesn't flicker off while moving across the pane.
-  const [dragOver, setDragOver] = useState(false);
-  const dragCount = useRef(0);
+  // Files dropped anywhere on the conversation attach to the composer: the composer owns the
+  // drop (ReifyUI), this pane is only its wider target.
+  const convRef = useRef<HTMLDivElement>(null);
   const canAttach = !!target.backend && !busy;
-  const onDragEnter = (e: React.DragEvent) => {
-    if (!canAttach || !Array.from(e.dataTransfer?.types || []).includes('Files')) return;
-    e.preventDefault();
-    dragCount.current += 1;
-    setDragOver(true);
-  };
-  const onDragOver = (e: React.DragEvent) => {
-    if (!canAttach || !Array.from(e.dataTransfer?.types || []).includes('Files')) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-  };
-  const onDragLeave = (e: React.DragEvent) => {
-    if (!dragOver) return;
-    e.preventDefault();
-    dragCount.current = Math.max(0, dragCount.current - 1);
-    if (dragCount.current === 0) setDragOver(false);
-  };
-  const onDrop = (e: React.DragEvent) => {
-    if (!canAttach) return;
-    e.preventDefault();
-    dragCount.current = 0;
-    setDragOver(false);
-    if (e.dataTransfer?.files?.length) void pickFiles(e.dataTransfer.files);
-  };
-
   return (
-    <div className={'wbx-conv' + (preview ? ' split' : '')}
-      onDragEnter={onDragEnter} onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop}>
-      {dragOver && (
-        <div className="wbx-droparea" aria-hidden="true">
-          <div className="wbx-droparea-inner">
-            <iconify-icon icon="tabler:file-upload"></iconify-icon>
-            Drop files to attach
-          </div>
-        </div>
-      )}
+    <div ref={convRef} className={'wbx-conv' + (preview ? ' split' : '')}>
       {/* A fresh draft centers on what it is for: the harness, named under its base's mark, with
           the composer right under it. The first message turns it into the running thread. */}
       <div className={'wbx-conv-main' + (!loading && msgs.length === 0 && !busy ? ' is-hero' : '')}>
@@ -650,6 +614,8 @@ function Conversation({ harnessId, sessionId, target, models, onModel, onRan, on
         disabled={!target.backend || busy}
         placeholder={!target.backend ? 'This harness is coming soon' : (sessionId || msgs.length > 0) ? `Reply to ${target.name}…` : 'Describe a task…'}
         inputRef={taRef}
+        onFiles={canAttach ? (l: FileList) => { void pickFiles(l); } : undefined}
+        dropTargetRef={convRef}
         attachments={files.length > 0 ? (
           <div className="wbx-attach-row in-composer">
             {files.map((f, j) => (


### PR DESCRIPTION
ReifyUI's Composer owns drag-and-drop now: `onFiles(FileList)` takes a drop on the composer or on the wider element a product names through `dropTargetRef`, and the composer lights up (`.is-dropping`, an outline) either way. The task view passes its conversation pane and loses its own handlers, overlay and styles; the reifyui pin moves to the commit that carries it (37f3f56).

Same change on the hosted console, where the Arena composer had no drop at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)