### PR TITLE
A plus on the Your harnesses row starts a custom harness right there

### DIFF
--- a/ui/src/app/(app)/harnesses/page.tsx
+++ b/ui/src/app/(app)/harnesses/page.tsx
@@ -204,15 +204,23 @@ export default function HarnessesPage() {
           {!rows ? <SkelListItems rows={4} /> : panel.length === 0 ? (
             <div className="hx-empty">{needle ? 'Nothing matches that.' : 'No harnesses yet.'}</div>
           ) : ([
-            { key: 'yours' as const, label: 'Your harnesses', items: panel.filter((x) => x.r.kind !== 'builtin'), empty: needle ? '' : 'None yet. Fork a system harness, or create one from the dashboard.' },
+            { key: 'yours' as const, label: 'Your harnesses', items: panel.filter((x) => x.r.kind !== 'builtin'), empty: needle ? '' : 'None yet. Fork a system harness, or create one.' },
             { key: 'system' as const, label: 'System harnesses', items: panel.filter((x) => x.r.kind === 'builtin'), empty: '' },
           ]).map((g) => (
             <div key={g.key} className={'hx-group' + (groupsOpen[g.key] || needle ? ' is-open' : '')}>
-              <button type="button" className="hx-group-btn" aria-expanded={groupsOpen[g.key] || !!needle} onClick={() => toggleGroup(g.key)}>
-                <iconify-icon icon={groupsOpen[g.key] || needle ? 'tabler:chevron-down' : 'tabler:chevron-right'} className="hx-caret"></iconify-icon>
-                <span className="hx-group-label">{g.label}</span>
-                <span className="hx-group-count">{g.items.length}</span>
-              </button>
+              <div className="hx-group-row">
+                <button type="button" className="hx-group-btn" aria-expanded={groupsOpen[g.key] || !!needle} onClick={() => toggleGroup(g.key)}>
+                  <iconify-icon icon={groupsOpen[g.key] || needle ? 'tabler:chevron-down' : 'tabler:chevron-right'} className="hx-caret"></iconify-icon>
+                  <span className="hx-group-label">{g.label}</span>
+                  <span className="hx-group-count">{g.items.length}</span>
+                </button>
+                {/* a custom harness starts here too, not only from the dashboard */}
+                {g.key === 'yours' && (
+                  <button type="button" className="hx-ic hx-group-add" title="New harness" aria-label="New harness" onClick={() => setAdding(true)}>
+                    <iconify-icon icon="tabler:plus"></iconify-icon>
+                  </button>
+                )}
+              </div>
               {(groupsOpen[g.key] || !!needle) && (g.items.length === 0 ? (g.empty ? <div className="hx-group-empty">{g.empty}</div> : null) : g.items.map(({ r, tasks, loaded, more, loading }) => {
             const isOpen = open === r.id || !!needle;
               const running = tasks.filter((c) => RUNNING.has(c.status || '')).length;

--- a/ui/src/app/v2.css
+++ b/ui/src/app/v2.css
@@ -456,6 +456,10 @@ body {
 .hx-group + .hx-group { margin-top: 6px; border-top: 1px solid var(--v2-line); padding-top: 8px; }
 .hx-group-btn { display: flex; align-items: center; gap: 7px; width: 100%; padding: 6px 12px 6px 14px; border: 0; background: none; cursor: pointer; color: var(--v2-sec); font: inherit; text-align: left; }
 .hx-group-btn:hover { color: var(--v2-ink); }
+.hx-group-row { display: flex; align-items: center; padding-right: 8px; }
+.hx-group-row .hx-group-btn { flex: 1; min-width: 0; }
+.hx-group-row .hx-group-add { opacity: 0; }
+.hx-group-row:hover .hx-group-add, .hx-group-add:focus-visible { opacity: 1; }
 .hx-group-btn .hx-caret { font-size: 14px; color: var(--v2-cap); flex: none; }
 .hx-group-label { font-size: 13px; font-weight: 500; }
 .hx-group-count { font-family: var(--v2-mono); font-size: 10.5px; color: var(--v2-cap); }


### PR DESCRIPTION
In the harnesses sidebar, the Your harnesses row carries a plus that opens the new-harness dialog, so a custom harness starts here and not only from the dashboard. The empty hint no longer points at the dashboard. Ported from the SaaS console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAkapU8wrgLXXFyB1ActQ4